### PR TITLE
[RPD-47] Fix CI on matcha repo to run with multiple python versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/setup-python@v4
         id: setup-python
         with:
-          python-version: 3.10.5
+          python-version: ${{ matrix.python-version }}
 
       # The key configuration value here is `virtualenvs-in-project: true`: this creates the
       # venv as a `.venv` in your testing directory, which allows the next step to easily


### PR DESCRIPTION
## Describe changes

The current [ci](https://github.com/fuzzylabs/matcha/blob/main/.github/workflows/ci.yml)  has a bug that it run github action with same python version.

## Checklist

Please ensure you have done the following:

- [x] I have read the [CONTRIBUTING](https://github.com/fuzzylabs/matcha/blob/main/CONTRIBUTING.md) guide. 
- [ ] I have updated the documentation if required.
- [ ] I have added tests which cover my changes.

## Type of change

Tick all those that apply:

- [x] Bug Fix (non-breaking change, fixing an issue)
- [ ] New feature (non-breaking change to add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (add details above)

To verify, notice how two separate caches are created for each python version [here](https://github.com/fuzzylabs/matcha/actions/caches).