### PR TITLE
Revert "[RPD-51] Get the bucket name and update matcha.state (#31)"

### DIFF
--- a/src/matcha_ml/templates/run_template.py
+++ b/src/matcha_ml/templates/run_template.py
@@ -19,10 +19,6 @@ from matcha_ml.cli.ui.status_message_builders import (
 from matcha_ml.errors import MatchaTerraformError
 
 MLFLOW_TRACKING_URL = "mlflow-tracking-url"
-ZENML_STORAGE_PATH = "zenml-storage-path"
-ZENML_CONNECTION_STRING = "zenml-connection-string"
-K8S_CONTEXT = "k8s-context"
-
 
 SPINNER = "dots"
 
@@ -266,14 +262,7 @@ class TerraformService:
         outputs = {
             MLFLOW_TRACKING_URL: self.terraform_client.output(
                 MLFLOW_TRACKING_URL, full_value=True
-            ),
-            ZENML_STORAGE_PATH: self.terraform_client.output(
-                ZENML_STORAGE_PATH, full_value=True
-            ),
-            ZENML_CONNECTION_STRING: self.terraform_client.output(
-                ZENML_CONNECTION_STRING, full_value=True
-            ),
-            K8S_CONTEXT: self.terraform_client.output(K8S_CONTEXT, full_value=True),
+            )
         }
 
         # dump specific terraform output to state file


### PR DESCRIPTION
This reverts commit c126cf3471b9e4b0759ff73eba4f9997bde1c19f.

## Describe changes

_Write a short description which explains what this pull request does and, briefly, how._

_If new dependencies are introduced to the project, please list them here:_

* _new dependency_

## Checklist

Please ensure you have done the following:

* [ ] I have read the [CONTRIBUTING](https://github.com/fuzzylabs/matcha/blob/main/CONTRIBUTING.md) guide.
* [ ] I have updated the documentation if required.
* [ ] I have added tests which cover my changes.

## Type of change

Tick all those that apply:

* [ ] Bug Fix (non-breaking change, fixing an issue)
* [ ] New feature (non-breaking change to add functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Other (add details above)

This is reverted as we should wait for RPD-50 to merge before RPD-51.