### PR TITLE
[RPD-56] [BUG] Fix the call to get the subscription_id in the AzureClient

### DIFF
--- a/src/matcha_ml/services/azure_service.py
+++ b/src/matcha_ml/services/azure_service.py
@@ -73,7 +73,7 @@ class AzureClient:
             return self._resource_group_names
         else:
             self._resource_client = ResourceManagementClient(
-                self._credential, str(self._subscription_id)
+                self._credential, str(self.subscription_id)
             )
             self._resource_group_names = {
                 resource_group.name


### PR DESCRIPTION
The following error is thrown: 

```bash
Message: The subscription identifier '<bound method AzureClient._subscription_id of <matcha_ml.services.azure_service.AzureClient object at 0x7fd1f5a58f70>>' 
exceeded the maximum length of '64' characters.
```

In AzureClient, the fetch_resource_group_names() function has been updated to get the subscription_id variable.

## Checklist

Please ensure you have done the following:

* [x] I have read the [CONTRIBUTING](https://github.com/fuzzylabs/matcha/blob/main/CONTRIBUTING.md) guide.
* [ ] I have updated the documentation if required.
* [ ] I have added tests which cover my changes.

## Type of change

Tick all those that apply:

* [x] Bug Fix (non-breaking change, fixing an issue)
* [ ] New feature (non-breaking change to add functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Other (add details above)
