### PR TITLE
[RPD-66] [BUG] Fix the regex for matching hyphens in the resource group prefix

### DIFF
--- a/src/matcha_ml/cli/_validation.py
+++ b/src/matcha_ml/cli/_validation.py
@@ -7,6 +7,7 @@ from typer import BadParameter
 from matcha_ml.errors import MatchaInputError
 from matcha_ml.services import AzureClient
 
+# TODO: dynamically set both of these variables
 LONGEST_RESOURCE_NAME = "artifactstore"
 MAXIMUM_RESOURCE_NAME_LEN = 24
 
@@ -50,11 +51,11 @@ def _is_not_digits(prefix: str) -> bool:
 PREFIX_RULES = {
     "numbers": {
         "func": _is_not_digits,
-        "message": "Resource group name cannot only contain numbers.",
+        "message": "Resource group name prefix cannot contain only numbers.",
     },
     "alphanumeric": {
         "func": _is_alphanumeric,
-        "message": "Resource group name prefix must only contain alphanumeric characters.",
+        "message": "Resource group name prefix can only contain alphanumeric characters.",
     },
     "length": {
         "func": _check_length,

--- a/tests/test_cli/test_provision.py
+++ b/tests/test_cli/test_provision.py
@@ -200,15 +200,15 @@ def test_cli_provision_command_with_verbose_arg(
     [
         (
             "uksouth\n-matcha-\nvalid\nno\n",
-            "Error: Resource group name prefix must only contain alphanumeric characters.",
+            "Error: Resource group name prefix can only contain alphanumeric characters.",
         ),
         (
             "uksouth\n12\nvalid\nno\n",
-            "Error: Resource group name cannot only contain numbers.",
+            "Error: Resource group name prefix cannot contain only numbers.",
         ),
         (
             "uksouth\ngood$prefix#\nvalid\nno\n",
-            "Error: Resource group name prefix must only contain alphanumeric characters.",
+            "Error: Resource group name prefix can only contain alphanumeric characters.",
         ),
         (
             "uksouth\nareallyloingprefix\nvalid\nno\n",
@@ -233,8 +233,6 @@ def test_cli_provision_command_prefix_rule(
     os.chdir(matcha_testing_directory)
 
     result = runner.invoke(app, ["provision"], input=user_input)
-
-    print(result.stdout)
 
     assert expected_output in result.stdout
 

--- a/tests/test_cli/test_validation.py
+++ b/tests/test_cli/test_validation.py
@@ -123,15 +123,19 @@ def test_is_not_digits(prefix: str, expectation: bool):
 @pytest.mark.parametrize(
     "prefix, error_msg, expectation",
     [
-        ("1234", "Resource group name cannot only contain numbers.", MatchaInputError),
+        (
+            "1234",
+            "Resource group name prefix cannot contain only numbers.",
+            MatchaInputError,
+        ),
         (
             "matcha&&",
-            "Resource group name prefix must only contain alphanumeric characters.",
+            "Resource group name prefix can only contain alphanumeric characters.",
             MatchaInputError,
         ),
         (
             "mat-cha",
-            "Resource group name prefix must only contain alphanumeric characters.",
+            "Resource group name prefix can only contain alphanumeric characters.",
             MatchaInputError,
         ),
         (
@@ -175,7 +179,7 @@ def test_prefix_typer_callback_expected(prefix: str, expectation: str):
     [
         (
             "matcha&&",
-            "Resource group name prefix must only contain alphanumeric characters.",
+            "Resource group name prefix can only contain alphanumeric characters.",
             BadParameter,
         ),
         (


### PR DESCRIPTION
The names of the storage accounts that we're provisioning must be lowercase letters and numbers, and must be between 3 and 24 characters. In our previous implementation of `_validation`, we did not account for this - a prefix with a hyphen in it would get through the validation checks and `provision` would fail.

This PR changes the `_validation` approach to address this issue. More broadly, rather than using regular expressions, the approach has been updated to use built-in Python functions. Checking the length has also been changed as the total number of characters cannot be more than 24 - we previously performed this check on the prefix, not taking into account the longest name of the resource we're provisioning.

Ensuring that the prefix is lowercase has also been introduced.

## Checklist

Please ensure you have done the following:

* [x] I have read the [CONTRIBUTING](https://github.com/fuzzylabs/matcha/blob/main/CONTRIBUTING.md) guide.
* [ ] I have updated the documentation if required.
* [x] I have added tests which cover my changes.

## Type of change

Tick all those that apply:

* [x] Bug Fix (non-breaking change, fixing an issue)
* [x] New feature (non-breaking change to add functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Other (add details above)
