### PR TITLE
[RPD-70] Remove 'describe changes' from PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,3 @@
-## Describe changes
-
 _Write a short description which explains what this pull request does and, briefly, how._
 
 _If new dependencies are introduced to the project, please list them here:_


### PR DESCRIPTION
The "Describe Changes" heading has been removed from the PR template as it's not needed - the text prompts are enough context for contributors to add detail. This is an improvement on the current PR template.

## Checklist

Please ensure you have done the following:

* [x] I have read the [CONTRIBUTING](https://github.com/fuzzylabs/matcha/blob/main/CONTRIBUTING.md) guide.
* [ ] I have updated the documentation if required.
* [ ] I have added tests which cover my changes.

## Type of change

Tick all those that apply:

* [ ] Bug Fix (non-breaking change, fixing an issue)
* [ ] New feature (non-breaking change to add functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Other (add details above)
