### PR TITLE
[REDUNDANT] [RPD-88] Pin ZenServer version in the terraform template to 0.36.1

### DIFF
--- a/src/matcha_ml/infrastructure/main.tf
+++ b/src/matcha_ml/infrastructure/main.tf
@@ -69,6 +69,9 @@ module "zenserver" {
   # ZenServer credentials
   username = var.username
   password = var.password
+
+  # Pin ZenServer version
+  zenmlserver_image_tag = "0.36.1"
 }
 
 

--- a/src/matcha_ml/infrastructure/zen_server/zen_server.tf
+++ b/src/matcha_ml/infrastructure/zen_server/zen_server.tf
@@ -17,6 +17,11 @@ resource "helm_release" "zen-server" {
   }
 
   set {
+    name  = "zenml.image.tag"
+    value = var.zenmlserver_image_tag
+  }
+
+  set {
     name  = "zenml.defaultUsername"
     value = var.username
   }


### PR DESCRIPTION
Pin the version of ZenServer deployed by matcha to 0.36.1. It matches the version of zenml in examples, and ensures that we do not need to update the client continuously, and we do not need to worry about compatibility issues

## Checklist

Please ensure you have done the following:

* [x] I have read the [CONTRIBUTING](https://github.com/fuzzylabs/matcha/blob/main/CONTRIBUTING.md) guide.
* [ ] I have updated the documentation if required.
* [ ] I have added tests which cover my changes.

## Type of change

Tick all those that apply:

* [x] Bug Fix (non-breaking change, fixing an issue)
* [ ] New feature (non-breaking change to add functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Other (add details above)
