### PR TITLE
[RPD-87] Fix failed matcha re-runs bug due to AKS node count

### DIFF
--- a/src/matcha_ml/infrastructure/aks/main.tf
+++ b/src/matcha_ml/infrastructure/aks/main.tf
@@ -11,7 +11,6 @@ resource "azurerm_kubernetes_cluster" "matcha_kubernetes_cluster" {
     enable_auto_scaling = true
     max_count           = 3
     min_count           = 1
-    node_count          = 2
   }
 
   identity {


### PR DESCRIPTION
Remove node count configuration and leave only min and max in AKS terraform configuration.

The fix can be tested by running `matcha provision` twice, without overriding the configuration; expected behaviour -- provisioning is successful both times. 

## Checklist

Please ensure you have done the following:

* [X] I have read the [CONTRIBUTING](https://github.com/fuzzylabs/matcha/blob/main/CONTRIBUTING.md) guide.
* [ ] I have updated the documentation if required.
* [ ] I have added tests which cover my changes.

## Type of change

Tick all those that apply:

* [X] Bug Fix (non-breaking change, fixing an issue)
* [ ] New feature (non-breaking change to add functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Other (add details above)
