### PR TITLE
[BUG] [RPD-67] Fix `matcha destroy` when no `.matcha` directory exists

### DIFF
--- a/src/matcha_ml/templates/run_template.py
+++ b/src/matcha_ml/templates/run_template.py
@@ -1,5 +1,6 @@
 """Run terraform templates to provision and deprovision resources."""
 import dataclasses
+import glob
 import json
 import os
 from pathlib import Path
@@ -102,18 +103,16 @@ class TerraformService:
             )
             raise typer.Exit()
 
-    
     def check_matcha_directory_integrity(self, directory_path: str) -> bool:
-        """Checks the integrity of the .matcha directory
-        
+        """Checks the integrity of the .matcha directory.
+
         Args:
             directory_path (str): .matcha directory path
 
         Returns:
-            bool: False if .matcha directory does not contain the infrastructure directory else True.
+            bool: False if .matcha directory is empty else True.
         """
-        return 'infrastructure' in os.listdir(directory_path)
-
+        return len(glob.glob(os.path.join(directory_path, "*"))) != 0
 
     def check_matcha_directory_exists(self) -> None:
         """Checks if .matcha directory exists within the current working directory.
@@ -127,9 +126,11 @@ class TerraformService:
                 f"Error, the .matcha directory does not exist in {os.getcwd()} . Please ensure you are trying to destroy resources that you have provisioned in the current working directory."
             )
             raise typer.Exit()
-        
+
         if not self.check_matcha_directory_integrity(matcha_dir_path):
-            print_error("Error, the .matcha directory does not contain files relating to deployed resources. Please ensure you are trying to destroy resources that you have provisioned in the current working directory.")
+            print_error(
+                "Error, the .matcha directory does not contain files relating to deployed resources. Please ensure you are trying to destroy resources that you have provisioned in the current working directory."
+            )
             raise typer.Exit()
 
     def validate_config(self) -> None:

--- a/tests/test_templates/test_run_template.py
+++ b/tests/test_templates/test_run_template.py
@@ -132,23 +132,22 @@ def test_check_installation_not_installed():
 
         with pytest.raises(typer.Exit):
             tfs.check_installation()
-              
-               
+
+
 def test_check_matcha_directory_exists(tmp_path: str):
     """Test app does not exit when .matcha file exists within current working directory.
-    
-    args:
+
+    Args:
         tmp_path (str): Pytest temporary path fixture for testing.
     """
     # Create a new directory within the temporary directory
     new_dir = tmp_path / ".matcha"
     os.mkdir(new_dir)
     os.chdir(tmp_path)
-    
+
     # Create an infrastructure directory in the new directory
     dir_name = "infrastructure"
-    dir_path = os.path.join(new_dir, dir_name)
-
+    os.path.join(new_dir, dir_name)
     os.mkdir(os.path.join(new_dir, dir_name))
 
     tfs = TerraformService()
@@ -158,13 +157,14 @@ def test_check_matcha_directory_exists(tmp_path: str):
         mock_tf_instance.cmd.return_value = (0, "", "")
 
         with does_not_raise():
-            result = tfs.check_matcha_directory_exists()
-                        
+            tfs.check_matcha_directory_exists()
+
     os.chdir("..")
-    
+
+
 def test_check_matcha_directory_is_empty(tmp_path):
     """Test app exits when .matcha file is empty.
-    
+
     Args:
         tmp_path (str): Pytest temporary path fixture for testing.
     """
@@ -182,13 +182,13 @@ def test_check_matcha_directory_is_empty(tmp_path):
         with pytest.raises(typer.Exit):
             result = tfs.check_matcha_directory_exists()
             assert "Error, the .matcha directory is empty." in result
-            
+
     os.chdir("..")
-    
+
 
 def test_check_matcha_directory_integrity(tmp_path):
     """Test returns False when .matcha file is empty.
-    
+
     Args:
         tmp_path (str): Pytest temporary path fixture for testing.
     """
@@ -205,15 +205,15 @@ def test_check_matcha_directory_integrity(tmp_path):
 
         result = tfs.check_matcha_directory_integrity(new_dir)
         assert result is False
-        
+
     os.chdir("..")
-    
+
 
 def test_check_matcha_directory_does_not_exist(tmp_path):
     """Test app exits when .matcha file does not exist within current working directory.
-    
+
     Args:
-        tmp_path (str): Pytest temporary path fixture for testing.    
+        tmp_path (str): Pytest temporary path fixture for testing.
     """
     tfs = TerraformService()
 


### PR DESCRIPTION
This PR adds a check to see if `.matcha` exists in the current working directory. If it does not exist the CLI is exited.

This prevents the error `Terraform is not installed` which is thrown during `destroy` if the `.matcha` file does not exist.

## Checklist

Please ensure you have done the following:

* [x] I have read the [CONTRIBUTING](https://github.com/fuzzylabs/matcha/blob/main/CONTRIBUTING.md) guide.
* [x] I have updated the documentation if required.
* [x] I have added tests which cover my changes.

## Type of change

Tick all those that apply:

* [x] Bug Fix (non-breaking change, fixing an issue)
* [ ] New feature (non-breaking change to add functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Other (add details above)
