### PR TITLE
[RPD-62] Update messages display when there's a existing .matcha directory to improve readability

### DIFF
--- a/src/matcha_ml/templates/build_templates/azure_template.py
+++ b/src/matcha_ml/templates/build_templates/azure_template.py
@@ -57,7 +57,7 @@ def reuse_configuration(path: str) -> bool:
     """
     if os.path.exists(path):
         confirmation_message = build_resource_confirmation(
-            "The following resources are already configured for provisioning",
+            "Matcha has detected that the following resources have already been configured for provisioning",
             [
                 ("Resource group", "A resource group"),
                 ("Azure Kubernetes Service (AKS)", "A kubernetes cluster"),
@@ -80,7 +80,7 @@ def reuse_configuration(path: str) -> bool:
         print_status(confirmation_message)
 
         return not typer.confirm(
-            "Do you want to override the configuration? Otherwise, the existing configuration will be reused"
+            "If you choose to override the existing configuration, the existing configuration will be deleted. Otherwise, the configuration will be reused.\n\nDo you want to override the existing configuration?"
         )
     else:
         return False


### PR DESCRIPTION
This PR updates the message for when there's already an existing .matcha directory improve readability.

Previously, if a `.matcha` already exist when running `matcha provision`, a message saying `"The following resources are already configured for provisioning"` and ask user where they would like to override the configuration. The new updated message aim to provided a clearer idea to the users on what will happened to the existing file by asking `"If you choose to override the existing configuration, the existing configuration will be deleted. Otherwise, the configuration will be reused.\n\nDo you want to override the existing configuration?"`

## Checklist

Please ensure you have done the following:

* [x] I have read the [CONTRIBUTING](https://github.com/fuzzylabs/matcha/blob/main/CONTRIBUTING.md) guide.
* [x] I have updated the documentation if required.
* [x] I have added tests which cover my changes.

## Type of change

Tick all those that apply:

* [ ] Bug Fix (non-breaking change, fixing an issue)
* [ ] New feature (non-breaking change to add functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Other (add details above)
