### PR TITLE
[RPD-111] [BUG] Check current deployment exists does not check the correct file path for the matcha.state file

### DIFF
--- a/src/matcha_ml/cli/_validation.py
+++ b/src/matcha_ml/cli/_validation.py
@@ -17,7 +17,9 @@ from matcha_ml.services import AzureClient
 LONGEST_RESOURCE_NAME = "artifactstore"
 MAXIMUM_RESOURCE_NAME_LEN = 24
 
-BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+MATCHA_STATE_DIR = os.path.join(
+    os.getcwd(), ".matcha", "infrastructure", "matcha.state"
+)
 
 
 def _is_alphanumeric(prefix: str) -> bool:
@@ -214,11 +216,10 @@ def check_current_deployment_exists() -> bool:
     Returns:
         bool: True if a deployment currently exists, else False.
     """
-    current_dir = os.getcwd()
-    if not os.path.isfile(f"{current_dir}/.matcha/infrastructure/matcha.state"):
+    if not os.path.isfile(MATCHA_STATE_DIR):
         return False
 
-    with open(f"{current_dir}/.matcha/infrastructure/matcha.state") as f:
+    with open(MATCHA_STATE_DIR) as f:
         data = json.load(f)
 
     resource_group_name = data["resource_group_name"]


### PR DESCRIPTION
Currently check_current_deployment_exists is checking the directory of the _validation file instead of where the function is being called. 

This means that when `matcha provision` is run in another directory (outside of matcha) it will simply return False from `check_current_deployment_exists` as it should check for the existence of `.../matcha-examples/recommendation/.matcha/infrastructure/matcha.state` but instead checks for `/matcha/src/matcha_ml/.matcha/infrastructure/matcha.state` which will almost never exist (unless `matcha provision` is run within the matcha directory itself. 



This has been updated to use os.getcwd() and also updated

```
    resource_group_name = data["resource-group-name"]
```

to

```
    resource_group_name = data["resource_group_name"]
```

due to the new matcha.state naming convention.

## Checklist

Please ensure you have done the following:

* [x] I have read the [CONTRIBUTING](https://github.com/fuzzylabs/matcha/blob/main/CONTRIBUTING.md) guide.
* [x] I have updated the documentation if required.
* [ ] I have added tests which cover my changes.

## Type of change

Tick all those that apply:

* [x] Bug Fix (non-breaking change, fixing an issue)
* [ ] New feature (non-breaking change to add functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Other (add details above)
