### PR TITLE
[RPD-81] Run LLM example on the remote stack

### DIFF
--- a/src/matcha_ml/infrastructure/aks/main.tf
+++ b/src/matcha_ml/infrastructure/aks/main.tf
@@ -6,7 +6,7 @@ resource "azurerm_kubernetes_cluster" "main" {
 
   default_node_pool {
     name    = "default"
-    vm_size = "Standard_DS2_v2"
+    vm_size = "Standard_DS3_v2"
 
     enable_auto_scaling = true
     max_count           = 3


### PR DESCRIPTION
Increase AKS node VM size so that LLM example fits until ZenML resource requests work properly.
This PR goes together with the example PR: https://github.com/fuzzylabs/matcha-examples/pull/23

## Checklist

Please ensure you have done the following:

* [x] I have read the [CONTRIBUTING](https://github.com/fuzzylabs/matcha/blob/main/CONTRIBUTING.md) guide.
* [ ] I have updated the documentation if required.
* [ ] I have added tests which cover my changes.

## Type of change

Tick all those that apply:

* [x] Bug Fix (non-breaking change, fixing an issue)
* [ ] New feature (non-breaking change to add functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Other (add details above)
