### PR TITLE
[RPD-120] Adds test for MatchaPermissionError

### DIFF
--- a/tests/test_templates/test_azure_template.py
+++ b/tests/test_templates/test_azure_template.py
@@ -97,6 +97,8 @@ def test_build_template_raises_permission_error(
     config = TemplateVariables("uksouth", "matcha", "superninja")
 
     destination_path = os.path.join(matcha_testing_directory, "infrastructure")
+
+    # Alters the permissions on the testing directory to be read-only
     os.chmod(matcha_testing_directory, S_IREAD)
 
     with pytest.raises(MatchaPermissionError):


### PR DESCRIPTION
This PR adds a test for raising a MatchaPermissionError where a user does not have access to write .matcha to the target directory. The test modifies the existing tempfile temporary directory to be read-only.


## Checklist

Please ensure you have done the following:

* [x] I have read the [CONTRIBUTING](https://github.com/fuzzylabs/matcha/blob/main/CONTRIBUTING.md) guide.
* [x] I have updated the documentation if required.
* [x] I have added tests which cover my changes.

## Type of change

Tick all those that apply:

* [x] Bug Fix (non-breaking change, fixing an issue)
* [ ] New feature (non-breaking change to add functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Other (add details above)
