### PR TITLE
[RPD-126] extends MatchaError class in specific matcha errors.

### DIFF
--- a/src/matcha_ml/errors.py
+++ b/src/matcha_ml/errors.py
@@ -16,7 +16,7 @@ class MatchaError(Exception):
         super().__init__(message, *args, **kwargs)
 
 
-class MatchaPermissionError(Exception):
+class MatchaPermissionError(MatchaError):
     """Matcha Permission Error.
 
     Raised when the user does not have the appropriate permissions.
@@ -33,7 +33,7 @@ class MatchaPermissionError(Exception):
         super().__init__(message, *args, **kwargs)
 
 
-class MatchaAuthenticationError(Exception):
+class MatchaAuthenticationError(MatchaError):
     """Matcha Authentication Error.
 
     Raised when the user is not authenticated with an external service.
@@ -51,7 +51,7 @@ class MatchaAuthenticationError(Exception):
         super().__init__(message, *args, **kwargs)
 
 
-class MatchaInputError(Exception):
+class MatchaInputError(MatchaError):
     """Matcha Input Error.
 
     Raised when the user inputs a bad value.
@@ -67,7 +67,7 @@ class MatchaInputError(Exception):
         super().__init__(*args, **kwargs)
 
 
-class MatchaTerraformError(Exception):
+class MatchaTerraformError(MatchaError):
     """Matcha Terraform Error.
 
     Raised when terraform fails to run.


### PR DESCRIPTION
This PR provides a small improvement through extending a default `MatchaError` class, rather than extending the `Exception` class in all of the custom matcha errors.

## Checklist

Please ensure you have done the following:

* [X] I have read the [CONTRIBUTING](https://github.com/fuzzylabs/matcha/blob/main/CONTRIBUTING.md) guide.
* [ ] I have updated the documentation if required.
* [ ] I have added tests which cover my changes.

## Type of change

Tick all those that apply:

* [ ] Bug Fix (non-breaking change, fixing an issue)
* [ ] New feature (non-breaking change to add functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [X] Other (add details above)
