### PR TITLE
[RPD-130] Add documentation page on example workflows

### DIFF
--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -1,1 +1,12 @@
-# MLOps Workflows
+# :building_construction: MLOps Workflows
+
+`matcha` is a tool for provisioning MLOps environments to the cloud and to give you some examples of how to use `matcha` in a practical setting, we've created a set of example workflows.
+
+You can find them [here](https://github.com/fuzzylabs/matcha-examples).
+
+Before you dive into the example workflows, you'll need to ensure that you have an Azure account with the correct level of permissions to deploy resources. We've created a guide on this, which can you can find [here](azure-permissions.md).
+
+The repository currently contains the following examples:
+
+1. [Movie Recommendation](https://github.com/fuzzylabs/matcha-examples/tree/main/recommendation).
+2. [Legal text summarisation using LLMs](https://github.com/fuzzylabs/matcha-examples/tree/main/llm).


### PR DESCRIPTION
This PR adds content to the currently empty `docs/workflows.md` page. The content describes what the workflows are, where the user can find them, and a note about Azure permissions.

To test:

```bash
mkdocs serve
```

## Checklist

Please ensure you have done the following:

* [x] I have read the [CONTRIBUTING](https://github.com/fuzzylabs/matcha/blob/main/CONTRIBUTING.md) guide.
* [x] I have updated the documentation if required.
* [ ] I have added tests which cover my changes.

## Type of change

Tick all those that apply:

* [ ] Bug Fix (non-breaking change, fixing an issue)
* [x] New feature (non-breaking change to add functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Other (add details above)
