### PR TITLE
[RPD-134] Fix `MatchaInputError` not raised in cli.py

### DIFF
--- a/src/matcha_ml/cli/cli.py
+++ b/src/matcha_ml/cli/cli.py
@@ -86,10 +86,10 @@ def get(
     """
     try:
         resources = core.get(resource_name, property_name)
-    except MatchaError as e:
+    except MatchaInputError as e:
         print_error(str(e))
         raise typer.Exit()
-    except MatchaInputError as e:
+    except MatchaError as e:
         print_error(str(e))
         raise typer.Exit()
 


### PR DESCRIPTION
This PR fixes the unreachable `MatchaInputError` in [cli.py](https://github.com/fuzzylabs/matcha/blob/main/src/matcha_ml/cli/cli.py), [line 92-94](https://github.com/fuzzylabs/matcha/blob/main/src/matcha_ml/cli/cli.py#L92) as it is a subclass of `MatchaError`. To fix this, MatchaInputError is now caught before MatchaError.

## Checklist

Please ensure you have done the following:

* [x] I have read the [CONTRIBUTING](https://github.com/fuzzylabs/matcha/blob/main/CONTRIBUTING.md) guide.
* [x] I have updated the documentation if required.
* [x] I have added tests which cover my changes.

## Type of change

Tick all those that apply:

* [x] Bug Fix (non-breaking change, fixing an issue)
* [ ] New feature (non-breaking change to add functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Other (add details above)
