### PR TITLE
[RPD-133] Error handling for hard exiting `matcha provision`

### DIFF
--- a/src/matcha_ml/services/terraform_service.py
+++ b/src/matcha_ml/services/terraform_service.py
@@ -99,9 +99,7 @@ class TerraformService:
             Path: a Path object that represents the path to the terraform.tfstate file
         directory.
         """
-        return Path(
-            os.path.join(self.terraform_client.working_dir, "terraform.tfstate")
-        )
+        return Path(os.path.join(self.config.working_dir, "terraform.tfstate"))
 
     def init(self) -> Tuple[int, str, str]:
         """Run `terraform init` with the initialised Terraform client from the python_terraform module.


### PR DESCRIPTION
It was discovered that running `matcha provision` and allowing the terraform initialisation to complete, but interrupting the terraform apply process, would lead to an error being thrown when interacting with matcha after this.

The bug was caused by `terraform_service.py > get_tf_state_dir` method accessing the `_terraform_client` getter, which in turn was trying to parse an existing but empty terraform.tfstate file. This was causing the an error to be thrown.

The fix is to not instantiate a `_terraform_client` within `get_tr_state_dir`. 

## Checklist

Please ensure you have done the following:

* [X] I have read the [CONTRIBUTING](https://github.com/fuzzylabs/matcha/blob/main/CONTRIBUTING.md) guide.
* [ ] I have updated the documentation if required.
* [ ] I have added tests which cover my changes.

## Type of change

Tick all those that apply:

* [X] Bug Fix (non-breaking change, fixing an issue)
* [ ] New feature (non-breaking change to add functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Other (add details above)
