### PR TITLE
[RPD-132] Move `matcha provision` existing deployment validations to the start of the command

### DIFF
--- a/src/matcha_ml/cli/_validation.py
+++ b/src/matcha_ml/cli/_validation.py
@@ -139,6 +139,9 @@ def region_typer_callback(region: str) -> str:
     Returns:
         str: the region after checks are passed.
     """
+    if not region:
+        return region
+
     try:
         region_validation(region)
     except MatchaInputError as e:
@@ -179,6 +182,8 @@ def prefix_typer_callback(prefix: str) -> str:
     Returns:
         str: if valid, the prefix is returned.
     """
+    if not prefix:
+        return prefix
 
     def _to_lowercase(prefix: str) -> str:
         """Convert the prefix to lowercase (a requirement of Azure).

--- a/src/matcha_ml/cli/cli.py
+++ b/src/matcha_ml/cli/cli.py
@@ -28,22 +28,17 @@ app = typer.Typer(no_args_is_help=True, pretty_exceptions_show_locals=False)
 @app.command()
 def provision(
     location: str = typer.Option(
-        None,
-        prompt="What region should your resources be provisioned in (e.g., 'ukwest')?",
         callback=region_typer_callback,
+        default="",
         help="The region where your resources will be provisioned, e.g., 'ukwest'",
     ),
     prefix: str = typer.Option(
-        prompt="Your resources need a name (an alphanumerical prefix; 3-11 character limit), what should matcha call them?",
         callback=prefix_typer_callback,
-        default="matcha",
+        default="",
         help="A unique prefix for your resources.",
     ),
     password: str = typer.Option(
-        default=None,
-        prompt="Set a password for your deployment server",
-        confirmation_prompt=True,
-        hide_input=True,
+        default="",
         help="A password for the deployment server",
     ),
     verbose: Optional[bool] = typer.Option(

--- a/src/matcha_ml/cli/provision.py
+++ b/src/matcha_ml/cli/provision.py
@@ -1,9 +1,10 @@
 """Provision CLI."""
 import os
-from typing import Optional
+from typing import Optional, Tuple
 
 import typer
 
+from matcha_ml.cli._validation import prefix_typer_callback, region_typer_callback
 from matcha_ml.cli.ui.print_messages import print_status
 from matcha_ml.cli.ui.status_message_builders import (
     build_status,
@@ -18,6 +19,44 @@ from matcha_ml.templates.run_template import TemplateRunner
 
 # create a typer app to group all provision subcommands
 app = typer.Typer()
+
+
+def fill_provision_variables(
+    location: str,
+    prefix: str,
+    password: str,
+) -> Tuple[str, str, str]:
+    """Prompt for the provision variables if they were not provided.
+
+    Args:
+        location (str): Azure location in which all resources will be provisioned, or empty string to fill in.
+        prefix (str): Prefix used for all resources, or empty string to fill in.
+        password (str): Password for ZenServer, or empty string to fill in.
+
+    Returns:
+        Tuple[str, str, str]: A tuple of location, prefix and password which were filled in
+    """
+    if not location:
+        location = typer.prompt(
+            default=None,
+            text="What region should your resources be provisioned in (e.g., 'ukwest')?",
+            value_proc=region_typer_callback,
+        )
+    if not prefix:
+        prefix = typer.prompt(
+            text="Your resources need a name (an alphanumerical prefix; 3-11 character limit), what should matcha call them?",
+            default="matcha",
+            value_proc=prefix_typer_callback,
+        )
+    if not password:
+        password = typer.prompt(
+            default=None,
+            text="Set a password for your deployment server",
+            confirmation_prompt=True,
+            hide_input=True,
+        )
+
+    return location, prefix, password
 
 
 def provision_resources(
@@ -45,6 +84,9 @@ def provision_resources(
     template = os.path.join(os.path.dirname(__file__), os.pardir, "infrastructure")
 
     if not reuse_configuration(destination):
+        location, prefix, password = fill_provision_variables(
+            location, prefix, password
+        )
         config = build_template_configuration(location, prefix, password)
         build_template(config, template, destination, verbose)
 

--- a/tests/test_cli/test_provision.py
+++ b/tests/test_cli/test_provision.py
@@ -281,7 +281,7 @@ def test_cli_provision_command_with_existing_prefix_name(
     result = runner.invoke(
         app,
         ["provision"],
-        input="uksouth\nrand\nvalid\ndefault\ndefault\nN\n",
+        input="N\nuksouth\nrand\nvalid\ndefault\ndefault\n",
     )
     assert expected_error_message in result.stdout
 

--- a/tests/test_cli/test_provision.py
+++ b/tests/test_cli/test_provision.py
@@ -281,7 +281,7 @@ def test_cli_provision_command_with_existing_prefix_name(
     result = runner.invoke(
         app,
         ["provision"],
-        input="N\nuksouth\nrand\nvalid\ndefault\ndefault\n",
+        input="uksouth\nrand\nvalid\ndefault\ndefault\nN\n",
     )
     assert expected_error_message in result.stdout
 


### PR DESCRIPTION
Ask for provisioning variables only after checking if there's an existing configuration.

Do not ask for the variables, if the configuration exists, and the user tells to not override it. Allow for empty variables in validation, so we do not make the CLI options mandatory. Prompt and fill in the variables only if they were not provided as CLI options.

## Checklist

Please ensure you have done the following:

* [x] I have read the [CONTRIBUTING](https://github.com/fuzzylabs/matcha/blob/main/CONTRIBUTING.md) guide.
* [ ] I have updated the documentation if required.
* [ ] I have added tests which cover my changes.

## Type of change

Tick all those that apply:

* [x] Bug Fix (non-breaking change, fixing an issue)
* [ ] New feature (non-breaking change to add functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Other (add details above)
