### PR TITLE
[RPD-141] Update the documentation link for matcha cli

### DIFF
--- a/src/matcha_ml/cli/cli.py
+++ b/src/matcha_ml/cli/cli.py
@@ -125,7 +125,7 @@ def cli(
 
     Run 'matcha <command> --help' for more information on a specific command.
 
-    For more help on how to use matcha, head to https://docs.mlops.wtf
+    For more help on how to use matcha, head to https://fuzzylabs.github.io/matcha/
     """
     pass
 


### PR DESCRIPTION
This PR updates the doc links shown when the`matcha` command is run. Previously, matcha command points to https://docs.mlops.wtf which have now been replaced by https://fuzzylabs.github.io/matcha/.

## Checklist

Please ensure you have done the following:

* [x] I have read the [CONTRIBUTING](https://github.com/fuzzylabs/matcha/blob/main/CONTRIBUTING.md) guide.
* [x] I have updated the documentation if required.
* [ ] I have added tests which cover my changes.

## Type of change

Tick all those that apply:

* [ ] Bug Fix (non-breaking change, fixing an issue)
* [ ] New feature (non-breaking change to add functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Other (add details above)
