### PR TITLE
[RPD-167] `provision` fails when run on the machine which has never done anything k8s related

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,4 +1,4 @@
-name: Docs 
+name: Docs
 on:
   push:
     paths:
@@ -21,7 +21,7 @@ jobs:
 
       - uses: actions/cache@v3
         with:
-          key: mkdocs-material-${{ github.ref }} 
+          key: mkdocs-material-${{ github.ref }}
           path: .cache
           restore-keys: |
             mkdocs-material-

--- a/src/matcha_ml/services/terraform_service.py
+++ b/src/matcha_ml/services/terraform_service.py
@@ -61,6 +61,18 @@ class TerraformService:
 
         return True
 
+    def verify_kubectl_config_file(self):
+        """Checks if kubeconfig is present at location ~/.kube/config.
+
+        If not, it creates a empty config file.
+        """
+        kubeconfig_path = os.path.join(os.path.expanduser("~"), ".kube/config")
+
+        if not os.path.exists(kubeconfig_path):
+            os.makedirs(os.path.dirname(kubeconfig_path), exist_ok=True)
+            with open(kubeconfig_path, "a"):
+                pass
+
     def check_matcha_directory_integrity(self) -> bool:
         """Checks the integrity of the .matcha directory.
 

--- a/src/matcha_ml/services/terraform_service.py
+++ b/src/matcha_ml/services/terraform_service.py
@@ -61,7 +61,7 @@ class TerraformService:
 
         return True
 
-    def verify_kubectl_config_file(self):
+    def verify_kubectl_config_file(self) -> None:
         """Checks if kubeconfig is present at location ~/.kube/config.
 
         If not, it creates a empty config file.

--- a/src/matcha_ml/services/terraform_service.py
+++ b/src/matcha_ml/services/terraform_service.py
@@ -65,7 +65,7 @@ class TerraformService:
         """Checks if kubeconfig is present at location ~/.kube/config.
 
         Args:
-            config_path (str): Path to location of kubeconfig
+            config_path (str): Relative path to location of kubeconfig
 
         If not, it creates a empty config file.
         """

--- a/src/matcha_ml/services/terraform_service.py
+++ b/src/matcha_ml/services/terraform_service.py
@@ -61,12 +61,15 @@ class TerraformService:
 
         return True
 
-    def verify_kubectl_config_file(self) -> None:
+    def verify_kubectl_config_file(self, config_path: str = ".kube/config") -> None:
         """Checks if kubeconfig is present at location ~/.kube/config.
+
+        Args:
+            config_path (str): Path to location of kubeconfig
 
         If not, it creates a empty config file.
         """
-        kubeconfig_path = os.path.join(os.path.expanduser("~"), ".kube/config")
+        kubeconfig_path = os.path.join(os.path.expanduser("~"), config_path)
 
         if not os.path.exists(kubeconfig_path):
             os.makedirs(os.path.dirname(kubeconfig_path), exist_ok=True)

--- a/src/matcha_ml/templates/run_template.py
+++ b/src/matcha_ml/templates/run_template.py
@@ -72,7 +72,7 @@ class TemplateRunner:
             )
             raise typer.Exit()
 
-    def _validate_kubeconfig(self):
+    def _validate_kubeconfig(self) -> None:
         """Check if kubeconfig file exists at location '~/.kube/config', if not create empty config file."""
         self.tfs.verify_kubectl_config_file()
 

--- a/src/matcha_ml/templates/run_template.py
+++ b/src/matcha_ml/templates/run_template.py
@@ -72,6 +72,10 @@ class TemplateRunner:
             )
             raise typer.Exit()
 
+    def _validate_kubeconfig(self):
+        """Check if kubeconfig file exists at location '~/.kube/config', if not create empty config file."""
+        self.tfs.verify_kubectl_config_file()
+
     def _initialize_terraform(self) -> None:
         """Run terraform init to initialize Terraform .
 
@@ -253,6 +257,7 @@ class TemplateRunner:
         """Provision resources required for the deployment."""
         self._check_terraform_installation()
         self._validate_terraform_config()
+        self._validate_kubeconfig()
         self._initialize_terraform()
         self._apply_terraform()
         self._show_terraform_outputs()

--- a/src/matcha_ml/templates/run_template.py
+++ b/src/matcha_ml/templates/run_template.py
@@ -72,13 +72,13 @@ class TemplateRunner:
             )
             raise typer.Exit()
 
-    def _validate_kubeconfig(self, config_path: str = ".kube/config") -> None:
+    def _validate_kubeconfig(self, base_path: str = ".kube/config") -> None:
         """Check if kubeconfig file exists at location '~/.kube/config', if not create empty config file.
 
         Args:
-            config_path (str): Path to location of kubeconfig
+            base_path (str): Relative path to location of kubeconfig
         """
-        self.tfs.verify_kubectl_config_file(config_path)
+        self.tfs.verify_kubectl_config_file(base_path)
 
     def _initialize_terraform(self) -> None:
         """Run terraform init to initialize Terraform .
@@ -261,7 +261,7 @@ class TemplateRunner:
         """Provision resources required for the deployment."""
         self._check_terraform_installation()
         self._validate_terraform_config()
-        self._validate_kubeconfig(".kube/config")
+        self._validate_kubeconfig(base_path=".kube/config")
         self._initialize_terraform()
         self._apply_terraform()
         self._show_terraform_outputs()

--- a/src/matcha_ml/templates/run_template.py
+++ b/src/matcha_ml/templates/run_template.py
@@ -72,9 +72,13 @@ class TemplateRunner:
             )
             raise typer.Exit()
 
-    def _validate_kubeconfig(self) -> None:
-        """Check if kubeconfig file exists at location '~/.kube/config', if not create empty config file."""
-        self.tfs.verify_kubectl_config_file()
+    def _validate_kubeconfig(self, config_path: str = ".kube/config") -> None:
+        """Check if kubeconfig file exists at location '~/.kube/config', if not create empty config file.
+
+        Args:
+            config_path (str): Path to location of kubeconfig
+        """
+        self.tfs.verify_kubectl_config_file(config_path)
 
     def _initialize_terraform(self) -> None:
         """Run terraform init to initialize Terraform .
@@ -257,7 +261,7 @@ class TemplateRunner:
         """Provision resources required for the deployment."""
         self._check_terraform_installation()
         self._validate_terraform_config()
-        self._validate_kubeconfig()
+        self._validate_kubeconfig(".kube/config")
         self._initialize_terraform()
         self._apply_terraform()
         self._show_terraform_outputs()

--- a/tests/test_services/test_terraform_service.py
+++ b/tests/test_services/test_terraform_service.py
@@ -118,28 +118,30 @@ def test_check_matcha_directory_integrity(tmp_path):
     os.chdir("..")
 
 
-def test_verify_kubectl_config_file(terraform_test_config: TerraformConfig):
+def test_verify_kubectl_config_file(tmpdir: str):
     """Test whether kubeconfig is present as path ~/.kube/config.
 
     Args:
-        terraform_test_config (TerraformConfig): test terraform service config
+        tmpdir (str): Temporary directory
     """
-    infrastructure_directory = terraform_test_config.working_dir
-    config_file_path = os.path.join(os.path.expanduser("~"), ".kube/config")
+    temp_path = tmpdir.mkdir(".kube").join("config")
+    tmp_config_file_path = os.path.join(os.path.expanduser("~"), temp_path)
 
-    with open(
-        os.path.join(infrastructure_directory, "terraform.tfvars.json"), "w"
-    ) as f:
-        f.write("{}")
+    # Check if path to config file does not exists
+    assert not os.path.exists(tmp_config_file_path)
+
+    # Check if config file is not present
+    assert not os.path.isfile(tmp_config_file_path)
 
     tfs = TerraformService()
-    tfs.config = terraform_test_config
+
+    tfs.verify_kubectl_config_file(tmp_config_file_path)
 
     # Check if path to config file exists
-    assert os.path.exists(config_file_path)
+    assert os.path.exists(tmp_config_file_path)
 
     # Check if config file is created
-    assert os.path.isfile(config_file_path)
+    assert os.path.isfile(tmp_config_file_path)
 
 
 def test_validate_config_exists(terraform_test_config: TerraformConfig):

--- a/tests/test_services/test_terraform_service.py
+++ b/tests/test_services/test_terraform_service.py
@@ -118,6 +118,30 @@ def test_check_matcha_directory_integrity(tmp_path):
     os.chdir("..")
 
 
+def test_verify_kubectl_config_file(terraform_test_config: TerraformConfig):
+    """Test whether kubeconfig is present as path ~/.kube/config.
+
+    Args:
+        terraform_test_config (TerraformConfig): test terraform service config
+    """
+    infrastructure_directory = terraform_test_config.working_dir
+    config_file_path = os.path.join(os.path.expanduser("~"), ".kube/config")
+
+    with open(
+        os.path.join(infrastructure_directory, "terraform.tfvars.json"), "w"
+    ) as f:
+        f.write("{}")
+
+    tfs = TerraformService()
+    tfs.config = terraform_test_config
+
+    # Check if path to config file exists
+    assert os.path.exists(config_file_path)
+
+    # Check if config file is created
+    assert os.path.isfile(config_file_path)
+
+
 def test_validate_config_exists(terraform_test_config: TerraformConfig):
     """Test service can validate that a config exists.
 


### PR DESCRIPTION
An error occurs when `~/.kube/config` file is missing following error occurs.

```bash
MatchaTerraformError: Terraform failed because of the following error: '
Error: Get "http://localhost/api/v1/namespaces/default/services/mlflow-tracking": dial tcp 127.0.0.1:80: connect: connection refused

  with module.mlflow.data.kubernetes_service.mlflow_tracking,
  on mlflow_module/getURI.tf line 2, in data "kubernetes_service" "mlflow_tracking":
   2: data "kubernetes_service" "mlflow_tracking" {
```

The solution: Create a `~/.kube/config` file if it does not exist before terraform apply.

## Checklist

Please ensure you have done the following:

* [x] I have read the [CONTRIBUTING](https://github.com/fuzzylabs/matcha/blob/main/CONTRIBUTING.md) guide.
* [ ] I have updated the documentation if required.
* [x] I have added tests which cover my changes.

## Type of change

Tick all those that apply:

* [x] Bug Fix (non-breaking change, fixing an issue)
* [ ] New feature (non-breaking change to add functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Other (add details above)
