### PR TITLE
[RPD-171] unable to destroy when provision fails part way through

### DIFF
--- a/src/matcha_ml/cli/_validation.py
+++ b/src/matcha_ml/cli/_validation.py
@@ -216,6 +216,8 @@ def prefix_typer_callback(prefix: str) -> str:
 def check_current_deployment_exists() -> bool:
     """Checks the current deployment using the .matcha directory current contents if it exists.
 
+    Specifically, it checks whether the resource group exists on Azure.
+
     Returns:
         bool: True if a deployment currently exists, else False.
     """

--- a/src/matcha_ml/cli/_validation.py
+++ b/src/matcha_ml/cli/_validation.py
@@ -229,6 +229,10 @@ def check_current_deployment_exists() -> bool:
     if "cloud" in data:
         resource_group_name = data["cloud"]["resource-group-name"]
 
+    # Alternate way to fetch resource-group-name from matcha.state file incase provision fails
+    if "prefix" in data:
+        resource_group_name = data["prefix"] + "-resources"
+
         client = get_azure_client()
         rg_state = client.resource_group_state(resource_group_name)
 

--- a/src/matcha_ml/cli/_validation.py
+++ b/src/matcha_ml/cli/_validation.py
@@ -226,10 +226,6 @@ def check_current_deployment_exists() -> bool:
         data = json.load(f)
 
     # Check if resource-group-name is present in matcha.state file
-    if "cloud" in data:
-        resource_group_name = data["cloud"]["resource-group-name"]
-
-    # Alternate way to fetch resource-group-name from matcha.state file incase provision fails
     if "prefix" in data:
         resource_group_name = data["prefix"] + "-resources"
 

--- a/src/matcha_ml/cli/_validation.py
+++ b/src/matcha_ml/cli/_validation.py
@@ -225,20 +225,24 @@ def check_current_deployment_exists() -> bool:
     with open(MATCHA_STATE_DIR) as f:
         data = json.load(f)
 
-    resource_group_name = data["cloud"]["resource-group-name"]
+    # Check if resource-group-name is present in matcha.state file
+    if "cloud" in data:
+        resource_group_name = data["cloud"]["resource-group-name"]
 
-    client = get_azure_client()
-    rg_state = client.resource_group_state(resource_group_name)
+        client = get_azure_client()
+        rg_state = client.resource_group_state(resource_group_name)
 
-    if rg_state is None:
-        return False
-    elif rg_state == ProvisionState.SUCCEEDED:
-        return True
+        if rg_state is None:
+            return False
+        elif rg_state == ProvisionState.SUCCEEDED:
+            return True
+        else:
+            print_error(
+                f"Error, resource group '{resource_group_name}' is currently in the state '{rg_state.value}' which is currently not handled by matcha. Please check your resources on Azure."
+            )
+            return True
     else:
-        print_error(
-            f"Error, resource group '{resource_group_name}' is currently in the state '{rg_state.value}' which is currently not handled by matcha. Please check your resources on Azure."
-        )
-        return True
+        return False
 
 
 def get_command_validation(argument: str, valid_options: List[str], noun: str) -> None:

--- a/src/matcha_ml/cli/cli.py
+++ b/src/matcha_ml/cli/cli.py
@@ -92,7 +92,7 @@ def get(
 
 @app.command()
 def destroy() -> None:
-    """Destroy the provisioned cloud resources."""
+    """Destroy the provisioned cloud resources. It will destroy the resource group even if resources are provisioned inside the group."""
     destroy_resources()
 
 

--- a/src/matcha_ml/cli/destroy.py
+++ b/src/matcha_ml/cli/destroy.py
@@ -20,14 +20,7 @@ def destroy_resources() -> None:
     # create a runner for deprovisioning resource with Terraform service.
     template_runner = TemplateRunner()
 
-    if not check_current_deployment_exists():
-        print_error(
-            "Error - you cannot destroy resources that have not been provisioned yet."
-        )
-        raise typer.Exit()
-
     if template_runner.is_approved(verb="destroy"):
-
         # deprovision the resources
         template_runner.deprovision()
         print_status(build_step_success_status("Destroying resources is complete!"))

--- a/src/matcha_ml/cli/destroy.py
+++ b/src/matcha_ml/cli/destroy.py
@@ -20,6 +20,12 @@ def destroy_resources() -> None:
     # create a runner for deprovisioning resource with Terraform service.
     template_runner = TemplateRunner()
 
+    if not check_current_deployment_exists():
+        print_error(
+            "Error - you cannot destroy resources that have not been provisioned yet."
+        )
+        raise typer.Exit()
+
     if template_runner.is_approved(verb="destroy"):
         # deprovision the resources
         template_runner.deprovision()

--- a/src/matcha_ml/infrastructure/main.tf
+++ b/src/matcha_ml/infrastructure/main.tf
@@ -1,5 +1,9 @@
 provider "azurerm" {
-  features {}
+  features {
+    resource_group {
+      prevent_deletion_if_contains_resources = false
+    }
+  }
 }
 
 module "resource_group" {

--- a/src/matcha_ml/templates/build_templates/azure_template.py
+++ b/src/matcha_ml/templates/build_templates/azure_template.py
@@ -175,8 +175,15 @@ def build_template(
             print_status(build_substep_success_status("Configuration was copied"))
 
         configuration_destination = os.path.join(destination, "terraform.tfvars.json")
+        statefile_destination = os.path.join(destination, "matcha.state")
+
+        config_dict = dataclasses.asdict(config)
         with open(configuration_destination, "w") as f:
-            json.dump(dataclasses.asdict(config), f)
+            json.dump(config_dict, f)
+
+        _ = config_dict.pop("password", None)
+        with open(statefile_destination, "w") as f:
+            json.dump(config_dict, f)
 
         if verbose:
             print_status(build_substep_success_status("Template variables were added."))

--- a/src/matcha_ml/templates/build_templates/azure_template.py
+++ b/src/matcha_ml/templates/build_templates/azure_template.py
@@ -175,14 +175,14 @@ def build_template(
             print_status(build_substep_success_status("Configuration was copied"))
 
         configuration_destination = os.path.join(destination, "terraform.tfvars.json")
-        statefile_destination = os.path.join(destination, "matcha.state")
+        state_file_destination = os.path.join(destination, "matcha.state")
 
         config_dict = dataclasses.asdict(config)
         with open(configuration_destination, "w") as f:
             json.dump(config_dict, f)
 
         _ = config_dict.pop("password", None)
-        with open(statefile_destination, "w") as f:
+        with open(state_file_destination, "w") as f:
             json.dump(config_dict, f)
 
         if verbose:

--- a/src/matcha_ml/templates/run_template.py
+++ b/src/matcha_ml/templates/run_template.py
@@ -195,13 +195,13 @@ class TemplateRunner:
 
         self._update_state_file(state_outputs)
 
-    def _update_state_file(self, state_outputs: dict) -> None:
+    def _update_state_file(self, state_outputs: Dict[str, Dict[str, str]]) -> None:
         """Read and update the matcha state file with new provisioned resources.
 
         Args:
-            state_outputs (dict): Dictionary containing outputs to be written to state file.
+            state_outputs (Dict[str, Dict[str, str]]): Dictionary containing outputs to be written to state file.
         """
-        with open(self.state_file, "r") as fp:
+        with open(self.state_file) as fp:
             out_data = json.load(fp)
         out_data.update(state_outputs)
         with open(self.state_file, "w") as fp:

--- a/src/matcha_ml/templates/run_template.py
+++ b/src/matcha_ml/templates/run_template.py
@@ -193,7 +193,7 @@ class TemplateRunner:
             state_outputs[resource_type].setdefault("flavor", flavor)
             state_outputs[resource_type][resource_name] = properties["value"]
 
-        with open(self.state_file, "a") as fp:
+        with open(self.state_file, "w") as fp:
             json.dump(state_outputs, fp, indent=4)
 
     def _show_terraform_outputs(self) -> None:

--- a/src/matcha_ml/templates/run_template.py
+++ b/src/matcha_ml/templates/run_template.py
@@ -193,7 +193,14 @@ class TemplateRunner:
             state_outputs[resource_type].setdefault("flavor", flavor)
             state_outputs[resource_type][resource_name] = properties["value"]
 
-        # Read and update the matcha state file with new provisioned resources.
+        self._update_state_file(state_outputs)
+
+    def _update_state_file(self, state_outputs: dict) -> None:
+        """Read and update the matcha state file with new provisioned resources.
+
+        Args:
+            state_outputs (dict): Dictionary containing outputs to be written to state file.
+        """
         with open(self.state_file, "r") as fp:
             out_data = json.load(fp)
         out_data.update(state_outputs)

--- a/src/matcha_ml/templates/run_template.py
+++ b/src/matcha_ml/templates/run_template.py
@@ -193,7 +193,7 @@ class TemplateRunner:
             state_outputs[resource_type].setdefault("flavor", flavor)
             state_outputs[resource_type][resource_name] = properties["value"]
 
-        with open(self.state_file, "w") as fp:
+        with open(self.state_file, "a") as fp:
             json.dump(state_outputs, fp, indent=4)
 
     def _show_terraform_outputs(self) -> None:

--- a/src/matcha_ml/templates/run_template.py
+++ b/src/matcha_ml/templates/run_template.py
@@ -193,8 +193,12 @@ class TemplateRunner:
             state_outputs[resource_type].setdefault("flavor", flavor)
             state_outputs[resource_type][resource_name] = properties["value"]
 
+        # Read and update the matcha state file with new provisioned resources.
+        with open(self.state_file, "r") as fp:
+            out_data = json.load(fp)
+        out_data.update(state_outputs)
         with open(self.state_file, "w") as fp:
-            json.dump(state_outputs, fp, indent=4)
+            json.dump(out_data, fp, indent=4)
 
     def _show_terraform_outputs(self) -> None:
         """Print the terraform outputs from state file."""

--- a/tests/test_cli/test_provision.py
+++ b/tests/test_cli/test_provision.py
@@ -50,6 +50,16 @@ def assert_infrastructure(destination_path: str, expected_tf_vars: Dict[str, str
 
     assert tf_vars == expected_tf_vars
 
+    # Check that matcha state file exists and content is equal/correct
+    state_file_path = os.path.join(destination_path, "matcha.state")
+    assert os.path.exists(state_file_path)
+
+    with open(state_file_path) as f:
+        tf_vars = json.load(f)
+
+    _ = expected_tf_vars.pop("password", None)
+    assert tf_vars == expected_tf_vars
+
 
 def test_cli_provision_command_help(runner: CliRunner):
     """Test cli for provision command help.

--- a/tests/test_cli/test_provision.py
+++ b/tests/test_cli/test_provision.py
@@ -296,12 +296,15 @@ def test_cli_provision_command_with_existing_prefix_name(
     assert expected_error_message in result.stdout
 
 
-def test_cli_provision_command_override(runner, matcha_testing_directory):
+def test_cli_provision_command_override(
+    runner, matcha_testing_directory, mocked_azure_client
+):
     """Test provision command to override the configuration file within the .matcha directory.
 
     Args:
         runner (CliRunner): typer CLI runner
         matcha_testing_directory (str): temporary working directory.
+        mocked_azure_client (AzureClient) : Mocked Azure client
     """
     os.chdir(matcha_testing_directory)
 
@@ -328,6 +331,7 @@ def test_cli_provision_command_override(runner, matcha_testing_directory):
     with open(os.path.join(destination_path, "dummy.tf"), "a"):
         ...
 
+    mocked_azure_client.resource_group_state.return_value = None
     # Invoke provision command for a second time, which overwrites the existing .matcha directory and removes the 'dummy.tf' file
     runner.invoke(
         app,

--- a/tests/test_templates/test_azure_template.py
+++ b/tests/test_templates/test_azure_template.py
@@ -62,6 +62,16 @@ def assert_infrastructure(destination_path: str, expected_tf_vars: Dict[str, str
 
     assert tf_vars == expected_tf_vars
 
+    # Check that matcha state file exists and content is equal/correct
+    state_file_path = os.path.join(destination_path, "matcha.state")
+    assert os.path.exists(state_file_path)
+
+    with open(state_file_path) as f:
+        tf_vars = json.load(f)
+
+    _ = expected_tf_vars.pop("password", None)
+    assert tf_vars == expected_tf_vars
+
 
 def test_build_template(matcha_testing_directory, template_src_path):
     """Test that the template is built and copied to correct locations.

--- a/tests/test_templates/test_run_template.py
+++ b/tests/test_templates/test_run_template.py
@@ -67,6 +67,8 @@ def expected_outputs_show_sensitive() -> Dict[str, Dict[str, str]]:
             "flavor": "azure",
             "registry-url": "azure_container_registry",
         },
+        "prefix": "random",
+        "location": "uksouth",
     }
 
     return outputs
@@ -98,6 +100,8 @@ def expected_outputs_hide_sensitive() -> dict:
             "flavor": "azure",
             "registry-url": "azure_container_registry",
         },
+        "prefix": "random",
+        "location": "uksouth",
     }
     return outputs
 
@@ -116,9 +120,16 @@ def terraform_test_config(matcha_testing_directory: str) -> TerraformConfig:
         matcha_testing_directory, ".matcha", "infrastructure"
     )
     os.makedirs(infrastructure_directory, exist_ok=True)
+
+    # Create a dummy matcha state file
+    matcha_state_file = os.path.join(infrastructure_directory, "matcha.state")
+    dummy_data = {"prefix": "random", "location": "uksouth"}
+    with open(matcha_state_file, "w") as fp:
+        json.dump(dummy_data, fp)
+
     return TerraformConfig(
         working_dir=infrastructure_directory,
-        state_file=os.path.join(infrastructure_directory, "matcha.state"),
+        state_file=matcha_state_file,
         var_file=os.path.join(infrastructure_directory, "terraform.tfvars.json"),
     )
 


### PR DESCRIPTION
The bug appears to be because the `matcha.state` file hasn't been created so the `check_current_deployment_exists()` function is returning False when checking whether the file exists (see this [line](https://github.com/fuzzylabs/matcha/blob/8170c91b2a34b15398f3b04c7b929a4b02116400/src/matcha_ml/cli/_validation.py#L222)). This means that there's no way for the user to destroy the partially provisioned resources without manually going to the Azure console - we want to avoid this.

`check_current_deployment_exists()` function has been modified to look for name of resource group in two different ways. That way even if resource group is created and provision fails in between, we should be able to run `matcha destroy` command.

The previous behavior was, `matcha destroy` would raise a error that no resources are provisioned even when resources are partially provisioned. This is due to how `check_current_deployment_exists` function checks for the resources. After modifying the behavior of the function, we are able to destroy the partially created resources using destroy command as well.

To test this, I interrupt in midway of `matcha provision` command and then run the `matcha destroy` command.

Here's how the process looks like

![image](https://github.com/fuzzylabs/matcha/assets/10743098/f66725db-0b00-49d5-9308-e69d24664f6a)


## Checklist

Please ensure you have done the following:

* [x] I have read the [CONTRIBUTING](https://github.com/fuzzylabs/matcha/blob/main/CONTRIBUTING.md) guide.
* [ ] I have updated the documentation if required.
* [x] I have added tests which cover my changes.

## Type of change

Tick all those that apply:

* [x] Bug Fix (non-breaking change, fixing an issue)
* [ ] New feature (non-breaking change to add functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Other (add details above)
