### PR TITLE
[RPD-169] Add unique identifier or ID to a state file

### DIFF
--- a/src/matcha_ml/templates/run_template.py
+++ b/src/matcha_ml/templates/run_template.py
@@ -195,7 +195,7 @@ class TemplateRunner:
             state_outputs[resource_type][resource_name] = properties["value"]
 
         # Create a unique matcha state identifier
-        state_outputs["id"] = {"matchaid": str(uuid.uuid4())}
+        state_outputs["id"] = {"matcha_uuid": str(uuid.uuid4())}
 
         self._update_state_file(state_outputs)
 

--- a/src/matcha_ml/templates/run_template.py
+++ b/src/matcha_ml/templates/run_template.py
@@ -1,6 +1,7 @@
 """Run terraform templates to provision and deprovision resources."""
 import json
 import os
+import uuid
 from collections import defaultdict
 from typing import Dict, Tuple
 
@@ -192,6 +193,9 @@ class TemplateRunner:
             )
             state_outputs[resource_type].setdefault("flavor", flavor)
             state_outputs[resource_type][resource_name] = properties["value"]
+
+        # Create a unique matcha state identifier
+        state_outputs["id"] = {"matchaid": str(uuid.uuid4())}
 
         with open(self.state_file, "w") as fp:
             json.dump(state_outputs, fp, indent=4)

--- a/tests/test_templates/test_run_template.py
+++ b/tests/test_templates/test_run_template.py
@@ -67,7 +67,7 @@ def expected_outputs_show_sensitive() -> Dict[str, Dict[str, str]]:
             "flavor": "azure",
             "registry-url": "azure_container_registry",
         },
-        "id": {"matchaid": "matcha_id_test_value"},
+        "id": {"matcha_uuid": "matcha_id_test_value"},
         "prefix": "random",
         "location": "uksouth",
     }
@@ -101,7 +101,7 @@ def expected_outputs_hide_sensitive() -> dict:
             "flavor": "azure",
             "registry-url": "azure_container_registry",
         },
-        "id": {"matchaid": "matcha_id_test_value"},
+        "id": {"matcha_uuid": "matcha_id_test_value"},
         "prefix": "random",
         "location": "uksouth",
     }

--- a/tests/test_templates/test_run_template.py
+++ b/tests/test_templates/test_run_template.py
@@ -67,6 +67,7 @@ def expected_outputs_show_sensitive() -> Dict[str, Dict[str, str]]:
             "flavor": "azure",
             "registry-url": "azure_container_registry",
         },
+        "id": {"matchaid": "matcha_id_test_value"},
     }
 
     return outputs
@@ -98,6 +99,7 @@ def expected_outputs_hide_sensitive() -> dict:
             "flavor": "azure",
             "registry-url": "azure_container_registry",
         },
+        "id": {"matchaid": "matcha_id_test_value"},
     }
     return outputs
 
@@ -289,7 +291,9 @@ def test_write_outputs_state(
     template_runner.tfs.terraform_client.output = MagicMock(wraps=mock_output)
 
     with does_not_raise():
-        template_runner._write_outputs_state()
+        with mock.patch("uuid.uuid4") as uuid4:
+            uuid4.return_value = "matcha_id_test_value"
+            template_runner._write_outputs_state()
         with open(terraform_test_config.state_file) as f:
             assert json.load(f) == expected_outputs_show_sensitive
 


### PR DESCRIPTION
In this ticket, we create a unique identifier for state file. To do this, we update the contents matcha.state file  with new identifier of following structure.

```json
{
        "orchestrator": {
            "flavor": "aks",
            "k8s-context": "k8s_test_context",
        },
        "container-registry": {
            "flavor": "azure",
            "registry-url": "azure_container_registry",
        },
        "id": {"matcha_uuid": "matcha_id_test_value"},
}
```

Here `id` field is added to exisiting dict with value `{"matcha_uuid": "matcha_id_test_value"}`. The `matcha_id_test_value` will consist of randomly generated UUID.

## Checklist

Please ensure you have done the following:

* [x] I have read the [CONTRIBUTING](https://github.com/fuzzylabs/matcha/blob/main/CONTRIBUTING.md) guide.
* [ ] I have updated the documentation if required.
* [x] I have added tests which cover my changes.

## Type of change

Tick all those that apply:

* [ ] Bug Fix (non-breaking change, fixing an issue)
* [x] New feature (non-breaking change to add functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Other (add details above)
