### PR TITLE
[RPD-181] Update README with raw links to images

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <h1 align="center">
-    <img src="docs/img/logo.png" width="200" style="max-width: 200px"></img>
+    <img src="https://raw.githubusercontent.com/fuzzylabs/matcha/main/docs/img/logo.png" width="200" style="max-width: 200px"></img>
 </h1>
 
 <p align="center">
@@ -26,7 +26,7 @@ If you train machine learning models, then you know the challenge of going from 
 **Matcha removes the complexity of provisioning your machine learning infrastructure**. With one step, you'll have a complete _machine learning operations (MLOps)_ stack up and running in your Microsoft® Azure cloud environment. This means you'll be able to track your experiments, train your models, as well as deploy and serve those models.
 
 <div align="center">
-    <img src="docs/img/matcha-provision.gif"></img>
+    <img src="https://raw.githubusercontent.com/fuzzylabs/matcha/main/docs/img/matcha-provision.gif"></img>
 </div>
 
 # &#127861; Who is Matcha for?


### PR DESCRIPTION
The image and GIF from the documentation [do not load on PyPi](https://pypi.org/project/matcha-ml/).

To fix this the image links that exist on the PyPi page are updated to the 'raw' links instead of the GitHub page e.g. for the GIF https://raw.githubusercontent.com/fuzzylabs/matcha/main/docs/img/matcha-provision.gif

NOTE: There may be better options for this as we are specifying the image existing on the main branch which could cause complications in the future when updating these images.

## Checklist

Please ensure you have done the following:

* [x] I have read the [CONTRIBUTING](https://github.com/fuzzylabs/matcha/blob/main/CONTRIBUTING.md) guide.
* [x] I have updated the documentation if required.
* [ ] I have added tests which cover my changes.

## Type of change

Tick all those that apply:

Docs fix

* [x] Bug Fix (non-breaking change, fixing an issue)
* [ ] New feature (non-breaking change to add functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Other (add details above)
