### PR TITLE
[RPD-183] Refactor `matcha analytics` command to display help when no argument passed

### DIFF
--- a/src/matcha_ml/cli/analytics.py
+++ b/src/matcha_ml/cli/analytics.py
@@ -5,7 +5,7 @@ from rich import print
 from matcha_ml.services.global_parameters_service import GlobalParameters
 
 # create a typer app to group all analytics subcommands
-app = typer.Typer(no_args_is_help=True)
+app = typer.Typer(no_args_is_help=True, pretty_exceptions_show_locals=False)
 
 
 @app.command()

--- a/src/matcha_ml/cli/analytics.py
+++ b/src/matcha_ml/cli/analytics.py
@@ -5,7 +5,7 @@ from rich import print
 from matcha_ml.services.global_parameters_service import GlobalParameters
 
 # create a typer app to group all analytics subcommands
-app = typer.Typer()
+app = typer.Typer(no_args_is_help=True)
 
 
 @app.command()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,7 +15,7 @@ INTERNAL_FUNCTION_STUB = "matcha_ml.services.AzureClient"
 
 
 @pytest.fixture
-def runner():
+def runner() -> CliRunner:
     """A fixture for cli runner."""
     return CliRunner()
 

--- a/tests/test_cli/test_analytics.py
+++ b/tests/test_cli/test_analytics.py
@@ -110,3 +110,18 @@ def test_opt_in_subcommand(
     # Check the contents of the config file match
     with open(config_file_path) as f:
         assert dict(yaml.safe_load(f)) == expected_configuration
+
+
+def test_cli__analytics_command_no_args(runner):
+    """Test cli analytics command when no argument passed."""
+    # Invoke analytics with no argument
+    result = runner.invoke(app, ["analytics"])
+
+    # Exit code 0 means there was no error
+    assert result.exit_code == 0
+
+    # Assert if particular string in present in output
+    assert (
+        "Enable or disable the collection of anonymous usage data (enabled by default)."
+        in result.stdout
+    )

--- a/tests/test_cli/test_analytics.py
+++ b/tests/test_cli/test_analytics.py
@@ -5,6 +5,7 @@ from unittest import mock
 
 import pytest
 import yaml
+from typer.testing import CliRunner
 
 from matcha_ml.cli.cli import app
 from matcha_ml.services.global_parameters_service import GlobalParameters
@@ -29,14 +30,14 @@ def expected_configuration() -> Dict[str, Union[str, bool]]:
 
 
 def test_opt_out_subcommand(
-    runner,
+    runner: CliRunner,
     matcha_testing_directory: str,
     expected_configuration: Dict[str, Union[str, bool]],
 ) -> None:
     """Test opt-out command works.
 
     Args:
-        runner: Mock runner
+        runner (CliRuner): Mock runner
         matcha_testing_directory (str): Temp directory
         expected_configuration (Dict[str, Union[str, bool]]): Dictionary containing expected configuration
     """
@@ -72,14 +73,14 @@ def test_opt_out_subcommand(
 
 
 def test_opt_in_subcommand(
-    runner,
+    runner: CliRunner,
     matcha_testing_directory: str,
     expected_configuration: Dict[str, Union[str, bool]],
 ) -> None:
     """Test opt-in command works.
 
     Args:
-        runner: Mock runner
+        runner (CliRuner): Mock runner
         matcha_testing_directory (str): Temp directory
         expected_configuration (Dict[str, Union[str, bool]]): Dictionary containing expected configuration
     """
@@ -112,8 +113,12 @@ def test_opt_in_subcommand(
         assert dict(yaml.safe_load(f)) == expected_configuration
 
 
-def test_cli__analytics_command_no_args(runner):
-    """Test cli analytics command when no argument passed."""
+def test_cli_analytics_command_no_args(runner: CliRunner) -> None:
+    """Test CLI analytics command displays the help message when no arguments are passed.
+
+    Args:
+        runner (CliRuner): Mock runner
+    """
     # Invoke analytics with no argument
     result = runner.invoke(app, ["analytics"])
 


### PR DESCRIPTION
This pull request adds default functionality to the `analytics` command, such that the `--help` option will be displayed by default where no other options, arguments, or sub-commands are passed. This is implemented by using typer's built-in `no_args_is_help=True` argument when creating the analytics sub-command branch.

One additional test has been included to test this functionality.

This PR also corrects for missing type definitions in relevant functions and modules.

## Checklist

Please ensure you have done the following:

* [X] I have read the [CONTRIBUTING](https://github.com/fuzzylabs/matcha/blob/main/CONTRIBUTING.md) guide.
* [ ] I have updated the documentation if required.
* [X] I have added tests which cover my changes.

## Type of change

Tick all those that apply:

* [ ] Bug Fix (non-breaking change, fixing an issue)
* [ ] New feature (non-breaking change to add functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [X] Other (add details above)
