### PR TITLE
[RPD-219] [BUG] `matcha.state` file to be updated on `destroy`

### DIFF
--- a/src/matcha_ml/cli/_validation.py
+++ b/src/matcha_ml/cli/_validation.py
@@ -17,9 +17,7 @@ from matcha_ml.services import AzureClient
 LONGEST_RESOURCE_NAME = "artifactstore"
 MAXIMUM_RESOURCE_NAME_LEN = 24
 
-MATCHA_STATE_DIR = os.path.join(
-    ".matcha", "infrastructure", "resources", "matcha.state"
-)
+MATCHA_STATE_DIR = os.path.join(".matcha", "infrastructure", "matcha.state")
 
 
 def _is_alphanumeric(prefix: str) -> bool:

--- a/src/matcha_ml/cli/cli.py
+++ b/src/matcha_ml/cli/cli.py
@@ -22,7 +22,7 @@ from matcha_ml.cli.ui.resource_message_builders import (
 from matcha_ml.core import core
 from matcha_ml.errors import MatchaError, MatchaInputError
 from matcha_ml.services.analytics_service import AnalyticsEvent, track
-from matcha_ml.state import RemoteStateManager
+from matcha_ml.state import MatchaStateService, RemoteStateManager
 
 app = typer.Typer(no_args_is_help=True, pretty_exceptions_show_locals=False)
 analytics_app = typer.Typer(no_args_is_help=True, pretty_exceptions_show_locals=False)
@@ -121,6 +121,8 @@ def destroy(
 
     if full:
         remote_state_manager.deprovision_state_storage()
+        matcha_state_service = MatchaStateService()
+        matcha_state_service.remove_matcha_state_file()
 
 
 def version_callback(value: bool) -> None:

--- a/src/matcha_ml/core/core.py
+++ b/src/matcha_ml/core/core.py
@@ -31,7 +31,7 @@ def get(
 
     if not matcha_state_service.state_file_exists:
         raise MatchaError(
-            f"Error: matcha.state file does not exist at {os.path.join(os.getcwd(), '.matcha', 'infrastructure', 'resources')} . Please run 'matcha provision' before trying to get the resource."
+            f"Error: matcha.state file does not exist at {os.path.join(os.getcwd(), '.matcha', 'infrastructure')} . Please run 'matcha provision' before trying to get the resource."
         )
 
     if resource_name:

--- a/src/matcha_ml/infrastructure/remote_state_storage/output.tf
+++ b/src/matcha_ml/infrastructure/remote_state_storage/output.tf
@@ -12,3 +12,13 @@ output "remote_state_storage_resource_group_name" {
   description = "Name of the resource group"
   value = module.resource_group.name
 }
+
+output "cloud_azure_prefix"{
+  description = "The Azure resource group name prefix"
+  value = var.prefix
+}
+
+output "cloud_azure_location"{
+  description = "The Azure location in which the resources are provisioned" 
+  value = var.location
+}

--- a/src/matcha_ml/infrastructure/resources/output.tf
+++ b/src/matcha_ml/infrastructure/resources/output.tf
@@ -56,5 +56,16 @@ output "model_deployer_seldon_base_url" {
 }
 
 output "cloud_azure_resource_group_name" {
+  description = "Name of the Azure resource group"
   value = module.resource_group.name
+}
+
+output "cloud_azure_prefix"{
+  description = "The Azure resource group name prefix"
+  value = var.prefix
+}
+
+output "cloud_azure_location"{
+  description = "The Azure location in which the resources are provisioned" 
+  value = var.location
 }

--- a/src/matcha_ml/services/terraform_service.py
+++ b/src/matcha_ml/services/terraform_service.py
@@ -16,12 +16,15 @@ class TerraformConfig:
     working_dir: str = os.path.join(
         os.getcwd(), ".matcha", "infrastructure", "resources"
     )
+    matcha_state_path: str = os.path.join(
+        os.getcwd(), ".matcha", "infrastructure", "matcha.state"
+    )
 
     # state file to store output after terraform apply
     @property
     def state_file(self) -> str:
         """The path to the state file."""
-        return os.path.join(self.working_dir, "matcha.state")
+        return self.matcha_state_path
 
     # variables file
     @property

--- a/src/matcha_ml/services/terraform_service.py
+++ b/src/matcha_ml/services/terraform_service.py
@@ -24,7 +24,7 @@ class TerraformConfig:
     @property
     def state_file(self) -> str:
         """The path to the state file."""
-        return self.matcha_state_path
+        return os.path.join(self.working_dir, "..", "matcha.state")
 
     # variables file
     @property

--- a/src/matcha_ml/state/matcha_state.py
+++ b/src/matcha_ml/state/matcha_state.py
@@ -77,3 +77,8 @@ class MatchaStateService:
             List[str]: a list of existing properties for a given resource.
         """
         return list(self._state.get(resource_name, {}).keys())
+
+    def remove_matcha_state_file(self) -> None:
+        """Removes the matcha.state file if it exists."""
+        if self.check_state_file_exists():
+            os.remove(self.matcha_state_dir)

--- a/src/matcha_ml/state/matcha_state.py
+++ b/src/matcha_ml/state/matcha_state.py
@@ -7,9 +7,7 @@ from typing import Dict, List, Optional
 class MatchaStateService:
     """A matcha state service for handling to matcha.state file."""
 
-    matcha_state_dir = os.path.join(
-        ".matcha", "infrastructure", "resources", "matcha.state"
-    )
+    matcha_state_dir = os.path.join(".matcha", "infrastructure", "matcha.state")
 
     def __init__(self) -> None:
         """MatchaStateService constructor."""

--- a/src/matcha_ml/state/remote_state_manager.py
+++ b/src/matcha_ml/state/remote_state_manager.py
@@ -187,7 +187,6 @@ class RemoteStateManager:
         print_status(
             build_step_success_status("Destroying remote state management is complete!")
         )
-        os.remove(MATCHA_STATE_DIR)
 
     def _write_matcha_config(
         self, account_name: str, container_name: str, resource_group_name: str

--- a/src/matcha_ml/state/remote_state_manager.py
+++ b/src/matcha_ml/state/remote_state_manager.py
@@ -19,6 +19,7 @@ from matcha_ml.templates.build_templates.state_storage_template import (
 from matcha_ml.templates.run_state_storage_template import TemplateRunner
 
 DEFAULT_CONFIG_NAME = "matcha.config.json"
+MATCHA_STATE_DIR = os.path.join(".matcha", "infrastructure", "matcha.state")
 
 
 @dataclasses.dataclass
@@ -186,6 +187,7 @@ class RemoteStateManager:
         print_status(
             build_step_success_status("Destroying remote state management is complete!")
         )
+        os.remove(MATCHA_STATE_DIR)
 
     def _write_matcha_config(
         self, account_name: str, container_name: str, resource_group_name: str

--- a/src/matcha_ml/templates/build_templates/azure_template.py
+++ b/src/matcha_ml/templates/build_templates/azure_template.py
@@ -175,7 +175,7 @@ def build_template(
             print_status(build_substep_success_status("Configuration was copied"))
 
         configuration_destination = os.path.join(destination, "terraform.tfvars.json")
-        state_file_destination = os.path.join(destination, "matcha.state")
+        state_file_destination = os.path.join(destination, "..", "matcha.state")
 
         config_dict = dataclasses.asdict(config)
         with open(configuration_destination, "w") as f:

--- a/src/matcha_ml/templates/run_template.py
+++ b/src/matcha_ml/templates/run_template.py
@@ -206,9 +206,6 @@ class TemplateRunner:
         Args:
             state_outputs (Dict[str, Dict[str, str]]): Dictionary containing outputs to be written to state file.
         """
-        print("AAAA")
-        print(self.state_file)
-        print("BBBB")
         with open(self.state_file, "w") as f:
             json.dump(state_outputs, f, indent=4)
 

--- a/src/matcha_ml/templates/run_template.py
+++ b/src/matcha_ml/templates/run_template.py
@@ -206,9 +206,6 @@ class TemplateRunner:
         Args:
             state_outputs (Dict[str, Dict[str, str]]): Dictionary containing outputs to be written to state file.
         """
-        with open(self.state_file) as f:
-            current_data = json.load(f)
-        state_outputs["cloud"].update(current_data["cloud"])
         with open(self.state_file, "w") as f:
             json.dump(state_outputs, f, indent=4)
 
@@ -281,8 +278,21 @@ class TemplateRunner:
         self._apply_terraform()
         self._show_terraform_outputs()
 
+    def _write_outputs_state_cloud_only(self) -> None:
+        """Write the outputs of the Terraform deployment to the state JSON file."""
+        with open(self.state_file) as f:
+            state_file_data = json.load(f)
+
+        updated_state_file_data = {}
+        for key, value in state_file_data.items():
+            if key in ["cloud", "id"]:
+                updated_state_file_data[key] = value
+
+        self._update_state_file(updated_state_file_data)
+
     def deprovision(self) -> None:
         """Destroy the provisioned resources."""
         self._check_matcha_directory_exists()
         self._check_terraform_installation()
         self._destroy_terraform()
+        self._write_outputs_state_cloud_only()

--- a/src/matcha_ml/templates/run_template.py
+++ b/src/matcha_ml/templates/run_template.py
@@ -206,6 +206,9 @@ class TemplateRunner:
         Args:
             state_outputs (Dict[str, Dict[str, str]]): Dictionary containing outputs to be written to state file.
         """
+        print("AAAA")
+        print(self.state_file)
+        print("BBBB")
         with open(self.state_file, "w") as f:
             json.dump(state_outputs, f, indent=4)
 

--- a/tests/test_cli/conftest.py
+++ b/tests/test_cli/conftest.py
@@ -37,12 +37,18 @@ def mocked_resource_template_runner() -> AzureTemplateRunner:
         f"{INTERNAL_FUNCTION_STUBS[0]}._check_terraform_installation"
     ) as check_tf_install, patch(
         f"{INTERNAL_FUNCTION_STUBS[0]}._validate_terraform_config"
-    ) as validate_tf_config:
+    ) as validate_tf_config, patch(
+        f"{INTERNAL_FUNCTION_STUBS[0]}._check_matcha_directory_exists"
+    ) as check_matcha_dir, patch(
+        f"{INTERNAL_FUNCTION_STUBS[0]}._destroy_terraform"
+    ) as destroy_terraform:
         initialize.return_value = None
         apply.return_value = None
         show.return_value = None
         check_tf_install.return_value = None
         validate_tf_config.return_value = None
+        check_matcha_dir.return_value = None
+        destroy_terraform.return_value = None
 
         yield AzureTemplateRunner()
 

--- a/tests/test_cli/test_destroy.py
+++ b/tests/test_cli/test_destroy.py
@@ -1,10 +1,12 @@
 """Test suite to test the destroy command and all its subcommands."""
+import json
 import os
 from unittest.mock import patch
 
 import pytest
 
 from matcha_ml.cli.cli import app
+from matcha_ml.templates.run_template import TemplateRunner
 
 
 @pytest.fixture(autouse=True)
@@ -45,7 +47,7 @@ def test_cli_destroy_command_with_no_provisioned_resources(
 
     # Invoke destroy command
     with patch(
-        "matcha_ml.templates.build_templates.azure_template.check_current_deployment_exists"
+        "matcha_ml.cli.destroy.check_current_deployment_exists"
     ) as check_deployment_exists:
         check_deployment_exists.return_value = False
         result = runner.invoke(app, ["destroy"])
@@ -54,3 +56,64 @@ def test_cli_destroy_command_with_no_provisioned_resources(
         "Error - you cannot destroy resources that have not been provisioned yet."
         in result.stdout
     )
+
+
+def test_cli_destroy_command_updates_matcha_state(runner, matcha_testing_directory):
+    """Test provision command updates the matcha state file when resources (excluding resource group and state bucket) are destroyed.
+
+    Args:
+        runner (CliRunner): typer CLI runner
+        matcha_testing_directory (str): temporary working directory.
+    """
+    os.chdir(matcha_testing_directory)
+
+    matcha_infrastructure_dir = os.path.join(".matcha", "infrastructure", "resources")
+    os.makedirs(matcha_infrastructure_dir)
+
+    state_file_resources = {
+        "cloud": {
+            "prefix": "test",
+            "location": "ukwest",
+            "flavor": "azure",
+            "resource-group-name": "test_resources",
+        },
+        "id": {"matcha_uuid": "TestStateID"},
+        "container-registry": {
+            "flavor": "azure",
+            "registry-name": "azure_registry_name",
+            "registry-url": "azure_container_registry",
+        },
+        "experiment-tracker": {"flavor": "mlflow", "tracking-url": "mlflow_test_url"},
+    }
+    state_file_path = os.path.join(matcha_infrastructure_dir, "matcha.state")
+
+    with open(state_file_path, "w") as f:
+        json.dump(state_file_resources, f)
+
+    expected_matcha_state_contents = {
+        "cloud": {
+            "prefix": "test",
+            "location": "ukwest",
+            "flavor": "azure",
+            "resource-group-name": "test_resources",
+        },
+        "id": {"matcha_uuid": "TestStateID"},
+    }
+
+    # Invoke destroy command
+    with patch(
+        "matcha_ml.cli.destroy.check_current_deployment_exists"
+    ) as check_deployment_exists, patch.object(
+        TemplateRunner, "state_file", state_file_path
+    ):
+        check_deployment_exists.return_value = True
+        runner.invoke(
+            app,
+            ["destroy"],
+            input="Y\n",
+        )
+
+    with open(os.path.join(matcha_infrastructure_dir, "matcha.state")) as f:
+        matcha_state_data = json.load(f)
+
+    assert matcha_state_data == expected_matcha_state_contents

--- a/tests/test_cli/test_destroy.py
+++ b/tests/test_cli/test_destroy.py
@@ -68,6 +68,8 @@ def test_cli_destroy_command_updates_matcha_state(runner, matcha_testing_directo
     os.chdir(matcha_testing_directory)
 
     matcha_infrastructure_dir = os.path.join(".matcha", "infrastructure", "resources")
+    matcha_state_file_path = os.path.join(".matcha", "infrastructure", "matcha.state")
+
     os.makedirs(matcha_infrastructure_dir)
 
     state_file_resources = {
@@ -85,9 +87,8 @@ def test_cli_destroy_command_updates_matcha_state(runner, matcha_testing_directo
         },
         "experiment-tracker": {"flavor": "mlflow", "tracking-url": "mlflow_test_url"},
     }
-    state_file_path = os.path.join(matcha_infrastructure_dir, "matcha.state")
 
-    with open(state_file_path, "w") as f:
+    with open(matcha_state_file_path, "w") as f:
         json.dump(state_file_resources, f)
 
     expected_matcha_state_contents = {
@@ -104,7 +105,7 @@ def test_cli_destroy_command_updates_matcha_state(runner, matcha_testing_directo
     with patch(
         "matcha_ml.cli.destroy.check_current_deployment_exists"
     ) as check_deployment_exists, patch.object(
-        TemplateRunner, "state_file", state_file_path
+        TemplateRunner, "state_file", matcha_state_file_path
     ):
         check_deployment_exists.return_value = True
         runner.invoke(
@@ -113,7 +114,7 @@ def test_cli_destroy_command_updates_matcha_state(runner, matcha_testing_directo
             input="Y\n",
         )
 
-    with open(os.path.join(matcha_infrastructure_dir, "matcha.state")) as f:
+    with open(matcha_state_file_path) as f:
         matcha_state_data = json.load(f)
 
     assert matcha_state_data == expected_matcha_state_contents

--- a/tests/test_cli/test_get.py
+++ b/tests/test_cli/test_get.py
@@ -30,6 +30,7 @@ def mock_state_file(matcha_testing_directory: str):
 
     matcha_infrastructure_dir = os.path.join(".matcha", "infrastructure", "resources")
     os.makedirs(matcha_infrastructure_dir)
+    matcha_state_file_path = os.path.join(".matcha", "infrastructure", "matcha.state")
 
     state_file_resources = {
         "pipeline": {
@@ -41,7 +42,7 @@ def mock_state_file(matcha_testing_directory: str):
         "experiment-tracker": {"flavor": "mlflow", "tracking-url": "mlflow_test_url"},
     }
 
-    with open(os.path.join(matcha_infrastructure_dir, "matcha.state"), "w") as f:
+    with open(matcha_state_file_path, "w") as f:
         json.dump(state_file_resources, f)
 
 
@@ -133,9 +134,7 @@ def test_cli_get_command_with_no_state_file(runner: CliRunner):
     Args:
         runner (CliRunner): typer CLI runner
     """
-    state_file_path = os.path.join(
-        ".matcha", "infrastructure", "resources", "matcha.state"
-    )
+    state_file_path = os.path.join(".matcha", "infrastructure", "matcha.state")
     os.remove(state_file_path)
 
     # Invoke get command

--- a/tests/test_cli/test_provision.py
+++ b/tests/test_cli/test_provision.py
@@ -67,7 +67,7 @@ def assert_infrastructure(
 
     if check_matcha_state_file:
         # Check that matcha state file exists and content is equal/correct
-        state_file_path = os.path.join(destination_path, "matcha.state")
+        state_file_path = os.path.join(destination_path, "..", "matcha.state")
         assert os.path.exists(state_file_path)
 
         with open(state_file_path) as f:

--- a/tests/test_core/test_core.py
+++ b/tests/test_core/test_core.py
@@ -26,6 +26,7 @@ def mock_state_file(matcha_testing_directory: str):
 
     matcha_infrastructure_dir = os.path.join(".matcha", "infrastructure", "resources")
     os.makedirs(matcha_infrastructure_dir)
+    matcha_state_file_path = os.path.join(".matcha", "infrastructure", "matcha.state")
 
     state_file_resources = {
         "cloud": {"flavor": "azure", "resource-group-name": "test_resources"},
@@ -37,7 +38,7 @@ def mock_state_file(matcha_testing_directory: str):
         "experiment-tracker": {"flavor": "mlflow", "tracking-url": "mlflow_test_url"},
     }
 
-    with open(os.path.join(matcha_infrastructure_dir, "matcha.state"), "w") as f:
+    with open(matcha_state_file_path, "w") as f:
         json.dump(state_file_resources, f)
 
 
@@ -88,9 +89,7 @@ def test_get_resources(expected_outputs: dict):
 
 def test_get_resources_without_state_file():
     """Test get resources function when a state file does not exist."""
-    state_file_path = os.path.join(
-        ".matcha", "infrastructure", "resources", "matcha.state"
-    )
+    state_file_path = os.path.join(".matcha", "infrastructure", "matcha.state")
     os.remove(state_file_path)
 
     with pytest.raises(MatchaError):

--- a/tests/test_state/test_matcha_state.py
+++ b/tests/test_state/test_matcha_state.py
@@ -28,6 +28,7 @@ def mock_state_file(matcha_testing_directory: str):
 
     matcha_infrastructure_dir = os.path.join(".matcha", "infrastructure", "resources")
     os.makedirs(matcha_infrastructure_dir)
+    matcha_state_file_path = os.path.join(".matcha", "infrastructure", "matcha.state")
 
     state_file_resources = {
         "cloud": {"flavor": "azure", "resource-group-name": "test_resources"},
@@ -39,7 +40,7 @@ def mock_state_file(matcha_testing_directory: str):
         "experiment-tracker": {"flavor": "mlflow", "tracking-url": "mlflow_test_url"},
     }
 
-    with open(os.path.join(matcha_infrastructure_dir, "matcha.state"), "w") as f:
+    with open(matcha_state_file_path, "w") as f:
         json.dump(state_file_resources, f)
 
 
@@ -113,7 +114,7 @@ def test_check_state_file_does_not_exist(matcha_state_service: MatchaStateServic
     Args:
         matcha_state_service (MatchaStateService): The matcha_state_service testing instance.
     """
-    matcha_infrastructure_dir = os.path.join(".matcha", "infrastructure", "resources")
-    os.remove(os.path.join(matcha_infrastructure_dir, "matcha.state"))
+    matcha_state_file_path = os.path.join(".matcha", "infrastructure", "matcha.state")
+    os.remove(matcha_state_file_path)
     result = matcha_state_service.check_state_file_exists()
     assert result is False

--- a/tests/test_state/test_remote_state_manager.py
+++ b/tests/test_state/test_remote_state_manager.py
@@ -68,7 +68,6 @@ def broken_config_testing_directory(matcha_testing_directory: str) -> str:
         str: temporary working directory path that the configuration was written to
     """
     config_path = os.path.join(matcha_testing_directory, DEFAULT_CONFIG_NAME)
-    print(config_path)
     content = {}
     with open(config_path, "w") as f:
         json.dump(content, f)

--- a/tests/test_templates/test_azure_template.py
+++ b/tests/test_templates/test_azure_template.py
@@ -63,7 +63,7 @@ def assert_infrastructure(destination_path: str, expected_tf_vars: Dict[str, str
     assert tf_vars == expected_tf_vars
 
     # Check that matcha state file exists and content is equal/correct
-    state_file_path = os.path.join(destination_path, "matcha.state")
+    state_file_path = os.path.join(destination_path, "..", "matcha.state")
     assert os.path.exists(state_file_path)
 
     with open(state_file_path) as f:

--- a/tests/test_templates/test_run_template.py
+++ b/tests/test_templates/test_run_template.py
@@ -28,6 +28,12 @@ def mock_output() -> Callable[[str, bool], Union[str, Dict[str, str]]]:
             "cloud_azure_resource_group_name": {
                 "value": "random-resources",
             },
+            "cloud_azure_prefix": {
+                "value": "random",
+            },
+            "cloud_azure_location": {
+                "value": "uksouth",
+            },
             "experiment_tracker_mlflow_tracking_url": {"value": "mlflow_test_url"},
             "pipeline_zenml_connection_string": {
                 "value": "zenml_test_connection_string"
@@ -404,6 +410,7 @@ def test_deprovision(template_runner: TemplateRunner):
     template_runner._check_terraform_installation = MagicMock()
     template_runner._check_matcha_directory_exists = MagicMock()
     template_runner._destroy_terraform = MagicMock()
+    template_runner._write_outputs_state_cloud_only = MagicMock()
 
     with mock.patch("typer.confirm") as mock_confirm:
         mock_confirm.return_value = False

--- a/tests/test_templates/test_run_template.py
+++ b/tests/test_templates/test_run_template.py
@@ -144,6 +144,8 @@ def terraform_test_config(matcha_testing_directory: str) -> TerraformConfig:
     with open(matcha_state_file, "w") as fp:
         json.dump(dummy_data, fp)
 
+    # TODO UPDATE STATE FILE LOCATION, CURRENTLY LOOKING AT LOCAL FILES INSTEAD OF TESTING DIR
+
     return TerraformConfig(working_dir=infrastructure_directory)
 
 
@@ -313,14 +315,20 @@ def test_write_outputs_state(
         expected_outputs_show_sensitive (dict): expected output from terraform
     """
     template_runner.state_file = terraform_test_config.state_file
+    print(terraform_test_config.state_file)
+    print(template_runner.state_file)
     template_runner.tfs.terraform_client.output = MagicMock(wraps=mock_output)
 
     with does_not_raise():
         with mock.patch("uuid.uuid4") as uuid4:
             uuid4.return_value = "matcha_id_test_value"
             template_runner._write_outputs_state()
-        with open(terraform_test_config.state_file) as f:
+        with open(terraform_test_config.state_file) as f, mock.patch.object(
+            TemplateRunner, "state_file", terraform_test_config.state_file
+        ):
             assert json.load(f) == expected_outputs_show_sensitive
+
+    assert False
 
 
 def test_show_terraform_outputs(

--- a/tests/test_templates/test_run_template.py
+++ b/tests/test_templates/test_run_template.py
@@ -144,8 +144,6 @@ def terraform_test_config(matcha_testing_directory: str) -> TerraformConfig:
     with open(matcha_state_file, "w") as fp:
         json.dump(dummy_data, fp)
 
-    # TODO UPDATE STATE FILE LOCATION, CURRENTLY LOOKING AT LOCAL FILES INSTEAD OF TESTING DIR
-
     return TerraformConfig(working_dir=infrastructure_directory)
 
 
@@ -327,8 +325,6 @@ def test_write_outputs_state(
             TemplateRunner, "state_file", terraform_test_config.state_file
         ):
             assert json.load(f) == expected_outputs_show_sensitive
-
-    assert False
 
 
 def test_show_terraform_outputs(

--- a/tests/test_templates/test_run_template.py
+++ b/tests/test_templates/test_run_template.py
@@ -137,7 +137,9 @@ def terraform_test_config(matcha_testing_directory: str) -> TerraformConfig:
     os.makedirs(infrastructure_directory, exist_ok=True)
 
     # Create a dummy matcha state file
-    matcha_state_file = os.path.join(infrastructure_directory, "matcha.state")
+    matcha_state_file = os.path.join(
+        matcha_testing_directory, ".matcha", "infrastructure", "matcha.state"
+    )
     dummy_data = {"cloud": {"prefix": "random", "location": "uksouth"}}
     with open(matcha_state_file, "w") as fp:
         json.dump(dummy_data, fp)

--- a/tests/test_templates/test_run_template.py
+++ b/tests/test_templates/test_run_template.py
@@ -313,8 +313,6 @@ def test_write_outputs_state(
         expected_outputs_show_sensitive (dict): expected output from terraform
     """
     template_runner.state_file = terraform_test_config.state_file
-    print(terraform_test_config.state_file)
-    print(template_runner.state_file)
     template_runner.tfs.terraform_client.output = MagicMock(wraps=mock_output)
 
     with does_not_raise():


### PR DESCRIPTION
This PR:

1. When `matcha destroy` is run `matcha.state` file is updated with the remaining resources.
2. When `matcha destroy full` is run `matcha.state` is removed completely
3. `matcha.state` file is moved from `.matcha/infrastructure/resources` to `.matcha/infrastructure`
4. Updated the way that `matcha.satate` is created and updated, it now uses terraform output variables

## Checklist

Please ensure you have done the following:

* [x] I have read the [CONTRIBUTING](https://github.com/fuzzylabs/matcha/blob/main/CONTRIBUTING.md) guide.
* [x] I have updated the documentation if required.
* [x] I have added tests which cover my changes.

## Type of change

Tick all those that apply:

* [x] Bug Fix (non-breaking change, fixing an issue)
* [ ] New feature (non-breaking change to add functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Other (add details above)
