### PR TITLE
[RPD-145] Get the state before `provision` or `destroy` command is run

### DIFF
--- a/src/matcha_ml/cli/destroy.py
+++ b/src/matcha_ml/cli/destroy.py
@@ -27,23 +27,24 @@ def destroy_resources() -> None:
         raise typer.Exit()
 
     with remote_state.use_lock():
-        # create a runner for deprovisioning resource with Terraform service.
-        template_runner = AzureTemplateRunner()
+        with RemoteStateManager.use_remote_state():
+            # create a runner for deprovisioning resource with Terraform service.
+            template_runner = AzureTemplateRunner()
 
-        if not check_current_deployment_exists():
-            print_error(
-                "Error - you cannot destroy resources that have not been provisioned yet."
-            )
-            raise typer.Exit()
-
-        if template_runner.is_approved(verb="destroy"):
-            # deprovision the resources
-            template_runner.deprovision()
-            print_status(build_step_success_status("Destroying resources is complete!"))
-        else:
-            print_status(
-                build_status(
-                    "You decided to cancel - your resources will remain active! If you change your mind, then run 'matcha destroy' again."
+            if not check_current_deployment_exists():
+                print_error(
+                    "Error - you cannot destroy resources that have not been provisioned yet."
                 )
-            )
-            raise typer.Exit()
+                raise typer.Exit()
+
+            if template_runner.is_approved(verb="destroy"):
+                # deprovision the resources
+                template_runner.deprovision()
+                print_status(build_step_success_status("Destroying resources is complete!"))
+            else:
+                print_status(
+                    build_status(
+                        "You decided to cancel - your resources will remain active! If you change your mind, then run 'matcha destroy' again."
+                    )
+                )
+                raise typer.Exit()

--- a/src/matcha_ml/cli/destroy.py
+++ b/src/matcha_ml/cli/destroy.py
@@ -27,7 +27,8 @@ def destroy_resources() -> None:
         raise typer.Exit()
 
     with remote_state.use_lock():
-        with RemoteStateManager.use_remote_state():
+
+        with remote_state.use_remote_state():
             # create a runner for deprovisioning resource with Terraform service.
             template_runner = AzureTemplateRunner()
 

--- a/src/matcha_ml/cli/provision.py
+++ b/src/matcha_ml/cli/provision.py
@@ -84,40 +84,41 @@ def provision_resources(
         remote_state_manager.provision_state_storage(location, prefix)
 
     with remote_state_manager.use_lock():
-        # create a runner for provisioning resource with Terraform service.
-        template_runner = AzureTemplateRunner()
+        with remote_state_manager.use_remote_state():
+            # create a runner for provisioning resource with Terraform service.
+            template_runner = AzureTemplateRunner()
 
-        project_directory = os.getcwd()
-        destination = os.path.join(
-            project_directory, ".matcha", "infrastructure", "resources"
-        )
-        template = os.path.join(
-            os.path.dirname(__file__), os.pardir, "infrastructure", "resources"
-        )
-
-        # Create a azure template object
-        azure_template = AzureTemplate()
-
-        if not azure_template.reuse_configuration(destination):
-            location, prefix, password = fill_provision_variables(
-                location, prefix, password
+            project_directory = os.getcwd()
+            destination = os.path.join(
+                project_directory, ".matcha", "infrastructure", "resources"
+            )
+            template = os.path.join(
+                os.path.dirname(__file__), os.pardir, "infrastructure", "resources"
             )
 
-            config = azure_template.build_template_configuration(
-                location=location, prefix=prefix, password=password
-            )
-            azure_template.build_template(config, template, destination, verbose)
+            # Create a azure template object
+            azure_template = AzureTemplate()
 
-        # Initializes the infrastructure provisioning process.
-        if template_runner.is_approved(verb="provision"):
-            # provision resources by running the template
-            template_runner.provision()
-            print_status(build_step_success_status("Provisioning is complete!"))
-
-        else:
-            print_status(
-                build_status(
-                    "You decided to cancel - if you change your mind, then run 'matcha provision' again."
+            if not azure_template.reuse_configuration(destination):
+                location, prefix, password = fill_provision_variables(
+                    location, prefix, password
                 )
-            )
-            raise typer.Exit()
+
+                config = azure_template.build_template_configuration(
+                    location=location, prefix=prefix, password=password
+                )
+                azure_template.build_template(config, template, destination, verbose)
+
+            # Initializes the infrastructure provisioning process.
+            if template_runner.is_approved(verb="provision"):
+                # provision resources by running the template
+                template_runner.provision()
+                print_status(build_step_success_status("Provisioning is complete!"))
+
+            else:
+                print_status(
+                    build_status(
+                        "You decided to cancel - if you change your mind, then run 'matcha provision' again."
+                    )
+                )
+                raise typer.Exit()

--- a/src/matcha_ml/state/remote_state_manager.py
+++ b/src/matcha_ml/state/remote_state_manager.py
@@ -261,8 +261,7 @@ class RemoteStateManager:
 
         yield None
 
-        matcha_resources_dir = os.path.join(".matcha", "infrastructure", "resources")
-        self.upload(matcha_resources_dir)
+        self.upload(os.path.join(".matcha", "infrastructure"))
 
     def lock(self) -> None:
         """Lock remote state.

--- a/src/matcha_ml/state/remote_state_manager.py
+++ b/src/matcha_ml/state/remote_state_manager.py
@@ -257,7 +257,12 @@ class RemoteStateManager:
         Downloads the state before executing the code.
         Upload the state when context is finished.
         """
-        yield
+        self.download(os.getcwd())
+
+        yield None
+
+        matcha_resources_dir = os.path.join(".matcha", "infrastructure", "resources")
+        self.upload(matcha_resources_dir)
 
     def lock(self) -> None:
         """Lock remote state.

--- a/src/matcha_ml/storage/azure_storage.py
+++ b/src/matcha_ml/storage/azure_storage.py
@@ -59,7 +59,7 @@ class AzureStorage:
             src_file (str): Path to upload the file from
         """
         with open(src_file, "rb") as blob_data:
-            blob_client.upload_blob(data=blob_data)
+            blob_client.upload_blob(data=blob_data, overwrite=True)
 
     def upload_folder(self, container_name: str, src_folder_path: str) -> None:
         """Upload a folder to Azure Storage Container.

--- a/tests/test_cli/test_provision.py
+++ b/tests/test_cli/test_provision.py
@@ -39,6 +39,15 @@ def mock_use_lock():
         yield mocked_use_lock
 
 
+@pytest.fixture(autouse=True)
+def mock_use_remote_state():
+    """Mock use_lock state context manager."""
+    with patch(
+        "matcha_ml.cli.provision.RemoteStateManager.use_remote_state"
+    ) as mocked_use_remote_state:
+        yield mocked_use_remote_state
+
+
 def assert_infrastructure(
     destination_path: str,
     expected_tf_vars: Dict[str, str],
@@ -117,11 +126,13 @@ def test_cli_provision_command(
     """
     os.chdir(matcha_testing_directory)
 
+    print("A")
     # Invoke provision command
     result = runner.invoke(
         app, ["provision"], input="uksouth\nmatcha\ndefault\ndefault\nY\n"
     )
 
+    print("HERE")
     # Exit code 0 means there was no error
     assert result.exit_code == 0
 

--- a/tests/test_cli/test_provision.py
+++ b/tests/test_cli/test_provision.py
@@ -126,13 +126,11 @@ def test_cli_provision_command(
     """
     os.chdir(matcha_testing_directory)
 
-    print("A")
     # Invoke provision command
     result = runner.invoke(
         app, ["provision"], input="uksouth\nmatcha\ndefault\ndefault\nY\n"
     )
 
-    print("HERE")
     # Exit code 0 means there was no error
     assert result.exit_code == 0
 

--- a/tests/test_state/test_remote_state_manager.py
+++ b/tests/test_state/test_remote_state_manager.py
@@ -432,4 +432,4 @@ def test_use_remote_state():
     with patch.object(remote_state_manager,"upload") as mocked_upload, patch.object(remote_state_manager,"download") as mocked_downlaod:
         with remote_state_manager.use_remote_state():
             mocked_downlaod.assert_called_once_with(os.getcwd())
-        mocked_upload.assert_called_once_with(os.path.join(".matcha", "infrastructure", "resources"))
+        mocked_upload.assert_called_once_with(os.path.join(".matcha", "infrastructure"))

--- a/tests/test_state/test_remote_state_manager.py
+++ b/tests/test_state/test_remote_state_manager.py
@@ -2,6 +2,7 @@
 import glob
 import json
 import os
+import shutil
 from typing import Dict, Iterator
 from unittest.mock import MagicMock, patch
 
@@ -419,3 +420,73 @@ def test_use_lock(
     assert mock_azure_storage_instance.create_empty.call_count == 1
     assert mock_azure_storage_instance.blob_exists.call_count == 1
     assert mock_azure_storage_instance.delete_blob.call_count == 1
+
+
+def test_use_remote_state(matcha_testing_directory: str):
+    """Test use_remote_state context manager executes functionality between downlaod and upload.
+
+    Args:
+        matcha_testing_directory (str): temporary working directory path.
+    """
+    mocked_azure_blob_path = os.path.join(matcha_testing_directory, "blob")
+    mocked_local_storage_path = os.path.join(matcha_testing_directory, "local")
+    mocked_azure_blob_file = os.path.join(mocked_azure_blob_path, "test", "test.txt")
+    mocked_local_storage_file = os.path.join(
+        mocked_local_storage_path, "test", "test.txt"
+    )
+    os.mkdir(mocked_azure_blob_path)
+    os.mkdir(mocked_local_storage_path)
+
+    def mocked_upload(*args) -> None:
+        """Mocked upload function for the use_remote_state context manager.
+
+        Args:
+            *args (str): placeholder for the upload function positional arguments.
+        """
+        shutil.copytree(
+            mocked_local_storage_path, mocked_azure_blob_path, dirs_exist_ok=True
+        )
+
+    def mocked_download(*args) -> None:
+        """Mocked download function for the use_remote_state context manager.
+
+        Args:
+            *args (str): placeholder for the download function positional arguments.
+        """
+        shutil.copytree(
+            mocked_azure_blob_path, mocked_local_storage_path, dirs_exist_ok=True
+        )
+
+    with patch.object(
+        RemoteStateManager, "download", new=mocked_download
+    ), patch.object(RemoteStateManager, "upload", new=mocked_upload):
+        remote_state_manager = RemoteStateManager()
+        # test create locally and upload
+        assert not os.path.isfile(mocked_azure_blob_file)
+        with remote_state_manager.use_remote_state():
+            os.mkdir(os.path.join(mocked_local_storage_path, "test"))
+            with open(os.path.join(mocked_local_storage_file), "w") as file:
+                file.write("Hello, world!")
+        assert os.path.isfile(os.path.join(mocked_local_storage_file))
+        assert os.path.isfile(mocked_azure_blob_file)
+        # test download from blob
+        shutil.rmtree(mocked_local_storage_path)
+        assert not os.path.isfile(os.path.join(mocked_local_storage_file))
+        with remote_state_manager.use_remote_state():
+            pass
+        assert os.path.isfile(os.path.join(mocked_local_storage_file))
+        # test overwrite blob
+        with open(mocked_azure_blob_file) as file:
+            assert file.read() == "Hello, world!"
+        with remote_state_manager.use_remote_state(), open(
+            os.path.join(mocked_local_storage_file), "w"
+        ) as file:
+            file.write("Hello, Matcha!")
+        with open(mocked_azure_blob_file) as file:
+            assert file.read() == "Hello, Matcha!"
+        # test delete from blob
+        # assert os.path.isfile(mocked_azure_blob_file)
+        # with remote_state_manager.use_remote_state():
+        #     shutil.rmtree(os.path.join(mocked_local_storage_path, "test"))
+        # assert not os.path.isfile(mocked_azure_blob_file)
+        # assert False

--- a/tests/test_state/test_remote_state_manager.py
+++ b/tests/test_state/test_remote_state_manager.py
@@ -423,10 +423,7 @@ def test_use_lock(
 
 
 def test_use_remote_state():
-    """Test use_remote_state context manager executes functionality between downlaod and upload.
-
-    Args:
-        matcha_testing_directory (str): temporary working directory path.
+    """Test use_remote_state context manager.
     """
     remote_state_manager = RemoteStateManager()
     with patch.object(remote_state_manager,"upload") as mocked_upload, patch.object(remote_state_manager,"download") as mocked_downlaod:


### PR DESCRIPTION
This pull request introduces a context manager that is used to download the state files from the remote storage before running `provision` or `destroy`, and upload files to the remote storage following the `provision` or `destroy` logic. The context manager uses the `contexlib` library and invokes `upload` and `download` from the `RemoteStateManager`.

## Checklist

Please ensure you have done the following:

* [x] I have read the [CONTRIBUTING](https://github.com/fuzzylabs/matcha/blob/main/CONTRIBUTING.md) guide.
* [ ] I have updated the documentation if required.
* [x] I have added tests which cover my changes.

## Type of change

Tick all those that apply:

* [ ] Bug Fix (non-breaking change, fixing an issue)
* [ ] New feature (non-breaking change to add functionality)
* [x] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Other (add details above)
