### PR TITLE
[RPD-229] [BUG] `download_folder` function tries to delete entire directory

### DIFF
--- a/src/matcha_ml/storage/azure_storage.py
+++ b/src/matcha_ml/storage/azure_storage.py
@@ -5,7 +5,6 @@ from typing import Set
 
 from azure.storage.blob import BlobClient, BlobServiceClient, ContainerClient
 
-from matcha_ml.errors import MatchaError
 from matcha_ml.services.azure_service import AzureClient
 
 
@@ -202,9 +201,6 @@ class AzureStorage:
 
         Args:
             dest_folder_path (str): Path to folder containing matcha resources
-
-        Raises:
-            MatchaError - If the `.matcha/infrasturcture/resources` directory is not found
         """
         # Clears the local matcha directory by removing all files,
         # ensuring that it exclusively contains the files retrieved from Azure remote storage
@@ -212,6 +208,4 @@ class AzureStorage:
             matcha_template_dir = os.path.join(os.getcwd(), ".matcha")
             shutil.rmtree(matcha_template_dir)
         else:
-            raise MatchaError(
-                f"Error - Failed to remove the .matcha directory as {dest_folder_path} directory not found."
-            )
+            print("Skipping deleting the '.matcha' folder")

--- a/src/matcha_ml/storage/azure_storage.py
+++ b/src/matcha_ml/storage/azure_storage.py
@@ -207,5 +207,3 @@ class AzureStorage:
         if os.path.exists(dest_folder_path):
             matcha_template_dir = os.path.join(os.getcwd(), ".matcha")
             shutil.rmtree(matcha_template_dir)
-        else:
-            print("Skipping deleting the '.matcha' folder")

--- a/src/matcha_ml/storage/azure_storage.py
+++ b/src/matcha_ml/storage/azure_storage.py
@@ -1,5 +1,5 @@
 """Class to interact with Azure Storage."""
-import glob
+import shutil
 import os
 from typing import Set
 
@@ -107,9 +107,10 @@ class AzureStorage:
             container_name (str): Azure storage container name
             dest_folder_path (str): Path to folder to download all the files
         """
-        # Clears the local directory by removing all files, ensuring that it exclusively contains the files retrieved from Azure remote storage
-        for file in glob.glob(os.path.join(dest_folder_path, "*")):
-            os.remove(file)
+        # Clears the local matcha directory by removing all files,
+        # ensuring that it exclusively contains the files retrieved from Azure remote storage
+        if os.path.exists(os.path.join(dest_folder_path, ".matcha")):
+            shutil.rmtree(os.path.join(dest_folder_path, ".matcha"))
 
         container_client = self._get_container_client(container_name)
 

--- a/tests/test_storage/test_azure_storage.py
+++ b/tests/test_storage/test_azure_storage.py
@@ -5,7 +5,6 @@ from unittest.mock import patch
 import pytest
 from azure.storage.blob import BlobProperties, BlobServiceClient
 
-from matcha_ml.errors import MatchaError
 from matcha_ml.services.azure_service import AzureClient
 from matcha_ml.storage.azure_storage import AzureStorage
 
@@ -434,29 +433,3 @@ def test_sync_local(
 
     assert not os.path.exists(matcha_resources_directory)
     assert not os.path.exists(matcha_remote_state_directory)
-
-
-def test_sync_local_raises_error(
-    mock_blob_service: BlobServiceClient, matcha_testing_directory: str
-) -> None:
-    """Test that sync local raises error if the .matcha/infrastrucutre/resources directory does not exist.
-
-    Args:
-        mock_blob_service (BlobServiceClient): Mocked blob service client.
-        matcha_testing_directory (str): Path to the matcha testing directory.
-    """
-    matcha_remote_state_directory = os.path.join(
-        matcha_testing_directory, ".matcha", "infrastructure", "remote_state_storage"
-    )
-    matcha_resources_directory = os.path.join(
-        matcha_testing_directory, ".matcha", "infrastructure", "resources"
-    )
-    os.chdir(matcha_testing_directory)
-
-    assert not os.path.exists(matcha_resources_directory)
-    assert not os.path.exists(matcha_remote_state_directory)
-
-    az_storage = AzureStorage("testaccount", "test-rg")
-
-    with pytest.raises(MatchaError):
-        az_storage._sync_local(matcha_resources_directory)


### PR DESCRIPTION
The [download_folder](https://github.com/fuzzylabs/matcha/blob/develop/src/matcha_ml/storage/azure_storage.py#LL101C1-L113C1) function inside `azure_storage.py`  tires to delete all the files inside the directory passed as argument i.e. `dest_folder_path`. 

To fix the bug, we only delete the `.matcha` folder when both remote_storage and resources folders are present inside `.matcha`  folder. This will ensure, we are uploading and downloading same folders i.e. remote state bucket acts as a oracle.

Detailed explanation can be found in the ticket.

## Checklist

Please ensure you have done the following:

* [x] I have read the [CONTRIBUTING](https://github.com/fuzzylabs/matcha/blob/main/CONTRIBUTING.md) guide.
* [ ] I have updated the documentation if required.
* [x] I have added tests which cover my changes.

## Type of change

Tick all those that apply:

* [x] Bug Fix (non-breaking change, fixing an issue)
* [ ] New feature (non-breaking change to add functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Other (add details above)
