### PR TITLE
[WIP] [RPD-220] Handle terraform cache better

### DIFF
--- a/src/matcha_ml/storage/azure_storage.py
+++ b/src/matcha_ml/storage/azure_storage.py
@@ -7,6 +7,8 @@ from azure.storage.blob import BlobClient, BlobServiceClient, ContainerClient
 
 from matcha_ml.services.azure_service import AzureClient
 
+IGNORE_FOLDERS = [".terraform"]
+
 
 class AzureStorage:
     """Class to interact with Azure blob storage."""
@@ -82,6 +84,10 @@ class AzureStorage:
         for root, _, filenames in os.walk(src_folder_path):
             for filename in filenames:
                 file_path = os.path.join(root, filename)
+
+                # ignore uploading files in the ignore folders
+                if any(folder in root for folder in IGNORE_FOLDERS):
+                    continue
 
                 if file_path in blob_set:
                     blob_set.remove(file_path)


### PR DESCRIPTION
The current workflow uploads terraform cache stored in `.terraform`. These folders range upto 500 MB in size. We want to avoid uploading these folders. Similarly, for downloading we want to avoid deleting these folder if already present as it takes time to initialize as well.

This PR introduces a way to fix for handling terraform cache while uploading and downloading while respecting the remote and local file structure.


## Checklist

Please ensure you have done the following:

* [ ] I have read the [CONTRIBUTING](https://github.com/fuzzylabs/matcha/blob/main/CONTRIBUTING.md) guide.
* [ ] I have updated the documentation if required.
* [ ] I have added tests which cover my changes.

## Type of change

Tick all those that apply:

* [ ] Bug Fix (non-breaking change, fixing an issue)
* [ ] New feature (non-breaking change to add functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Other (add details above)
