### PR TITLE
[RPD-231] Improvements to `provision` and `destroy` logging

### DIFF
--- a/src/matcha_ml/cli/cli.py
+++ b/src/matcha_ml/cli/cli.py
@@ -124,7 +124,7 @@ def destroy(
     remote_state_manager = RemoteStateManager()
     with Spinner("Preparing to destroy..."):
         if full:
-            destroy_resources(resources=RESOURCE_MSG + STATE_RESOURCE_MSG)
+            destroy_resources(resources=STATE_RESOURCE_MSG + RESOURCE_MSG)
             remote_state_manager.deprovision_remote_state()
         else:
             print_status(

--- a/src/matcha_ml/cli/cli.py
+++ b/src/matcha_ml/cli/cli.py
@@ -20,7 +20,6 @@ from matcha_ml.cli.ui.resource_message_builders import (
     build_resource_output,
     hide_sensitive_in_output,
 )
-from matcha_ml.cli.ui.spinner import Spinner
 from matcha_ml.cli.ui.status_message_builders import build_warning_status
 from matcha_ml.core import core
 from matcha_ml.errors import MatchaError, MatchaInputError
@@ -122,17 +121,16 @@ def destroy(
 ) -> None:
     """Destroy the provisioned cloud resources."""
     remote_state_manager = RemoteStateManager()
-    with Spinner("Preparing to destroy..."):
-        if full:
-            destroy_resources(resources=STATE_RESOURCE_MSG + RESOURCE_MSG)
-            remote_state_manager.deprovision_remote_state()
-        else:
-            print_status(
-                build_warning_status(
-                    "Warning: a storage container holding Matcha state information will persist. To destroy ALL clound resources, run 'matcha destroy full'."
-                )
+    if full:
+        destroy_resources(resources=STATE_RESOURCE_MSG + RESOURCE_MSG)
+        remote_state_manager.deprovision_remote_state()
+    else:
+        print_status(
+            build_warning_status(
+                "Warning: a storage container holding Matcha state information will persist. To destroy ALL clound resources, run 'matcha destroy full'."
             )
-            destroy_resources(resources=RESOURCE_MSG)
+        )
+        destroy_resources(resources=RESOURCE_MSG)
 
 
 @app.command()

--- a/src/matcha_ml/cli/cli.py
+++ b/src/matcha_ml/cli/cli.py
@@ -8,19 +8,20 @@ from matcha_ml.cli._validation import (
     prefix_typer_callback,
     region_typer_callback,
 )
+from matcha_ml.cli.constants import RESOURCE_MSG, STATE_RESOURCE_MSG
 from matcha_ml.cli.destroy import destroy_resources
 from matcha_ml.cli.provision import provision_resources
-from matcha_ml.cli.ui.spinner import Spinner
 from matcha_ml.cli.ui.print_messages import (
     print_error,
     print_resource_output,
     print_status,
 )
-from matcha_ml.cli.ui.status_message_builders import build_warning_status
 from matcha_ml.cli.ui.resource_message_builders import (
     build_resource_output,
     hide_sensitive_in_output,
 )
+from matcha_ml.cli.ui.spinner import Spinner
+from matcha_ml.cli.ui.status_message_builders import build_warning_status
 from matcha_ml.core import core
 from matcha_ml.errors import MatchaError, MatchaInputError
 from matcha_ml.services.analytics_service import AnalyticsEvent, track
@@ -123,45 +124,16 @@ def destroy(
     remote_state_manager = RemoteStateManager()
     with Spinner("Preparing to destroy..."):
         if full:
-            resources = [
-                    ("Azure Kubernetes Service (AKS)", "A kubernetes cluster"),
-                    (
-                        "Three Storage Containers",
-                        "Storage containers for tracking Matcha state, for experiment tracking artifacts and for model training artifacts",
-                    ),
-                    (
-                        "Seldon Core",
-                        "A framework for model deployment on top of a kubernetes cluster",
-                    ),
-                    (
-                        "Azure Container Registry",
-                        "A container registry for storing docker images",
-                    ),
-                    ("ZenServer", "A zenml server required for remote orchestration"),
-                ]
-
-            destroy_resources(resources=resources)
+            destroy_resources(resources=RESOURCE_MSG + STATE_RESOURCE_MSG)
             remote_state_manager.deprovision_remote_state()
         else:
-            print_status(build_warning_status("Warning: a storage container holding Matcha state information will persist. To destroy ALL clound resources, run 'matcha destroy full'."))
-            resources = [
-                    ("Azure Kubernetes Service (AKS)", "A kubernetes cluster"),
-                    (
-                        "Two Storage Containers",
-                        "A storage container for experiment tracking artifacts and a second for model training artifacts",
-                    ),
-                    (
-                        "Seldon Core",
-                        "A framework for model deployment on top of a kubernetes cluster",
-                    ),
-                    (
-                        "Azure Container Registry",
-                        "A container registry for storing docker images",
-                    ),
-                    ("ZenServer", "A zenml server required for remote orchestration"),
-                ]
+            print_status(
+                build_warning_status(
+                    "Warning: a storage container holding Matcha state information will persist. To destroy ALL clound resources, run 'matcha destroy full'."
+                )
+            )
+            destroy_resources(resources=RESOURCE_MSG)
 
-            destroy_resources(resources=resources)
 
 @app.command()
 def force_unlock() -> None:

--- a/src/matcha_ml/cli/constants.py
+++ b/src/matcha_ml/cli/constants.py
@@ -1,0 +1,21 @@
+"""Constants for use within the Matcha CLI."""
+RESOURCE_MSG = [
+    ("Azure Kubernetes Service (AKS)", "A kubernetes cluster"),
+    (
+        "Two Storage Containers",
+        "A storage container for experiment tracking artifacts and a second for model training artifacts",
+    ),
+    (
+        "Seldon Core",
+        "A framework for model deployment on top of a kubernetes cluster",
+    ),
+    (
+        "Azure Container Registry",
+        "A container registry for storing docker images",
+    ),
+    ("ZenServer", "A zenml server required for remote orchestration"),
+]
+
+STATE_RESOURCE_MSG = [
+    ("Matcha State Container", "A storage container for tracking matcha state")
+]

--- a/src/matcha_ml/cli/constants.py
+++ b/src/matcha_ml/cli/constants.py
@@ -17,5 +17,6 @@ RESOURCE_MSG = [
 ]
 
 STATE_RESOURCE_MSG = [
-    ("Matcha State Container", "A storage container for tracking matcha state")
+    ("Azure Resource Group", "The resource group containing the provisioned resources"),
+    ("Matcha State Container", "A storage container for tracking matcha state"),
 ]

--- a/src/matcha_ml/cli/destroy.py
+++ b/src/matcha_ml/cli/destroy.py
@@ -1,4 +1,6 @@
 """Destroy CLI."""
+from typing import List, Tuple
+
 import typer
 
 from matcha_ml.cli._validation import check_current_deployment_exists
@@ -11,11 +13,11 @@ from matcha_ml.runners import AzureRunner
 from matcha_ml.state import RemoteStateManager
 
 
-def destroy_resources(resources: list) -> None:
+def destroy_resources(resources: List[Tuple[str, str]]) -> None:
     """Destroy resources.
 
     Args:
-        resources(list): the list of resources to be actioned by the verb to be provided to the user as a status message
+        resources (list[str]): the list of resources to be actioned by the verb to be provided to the user as a status message
 
     Raises:
         typer.Exit: Exit if matcha remote state has not been provisioned.
@@ -29,27 +31,24 @@ def destroy_resources(resources: list) -> None:
         )
         raise typer.Exit()
 
-    with remote_state.use_lock():
-        with remote_state.use_remote_state():
-            # create a runner for deprovisioning resource with Terraform service.
-            template_runner = AzureRunner()
+    with remote_state.use_lock(), remote_state.use_remote_state():
+        # create a runner for deprovisioning resource with Terraform service.
+        template_runner = AzureRunner()
 
-            if not check_current_deployment_exists():
-                print_error(
-                    "Error - you cannot destroy resources that have not been provisioned yet."
-                )
-                raise typer.Exit()
+        if not check_current_deployment_exists():
+            print_error(
+                "Error - you cannot destroy resources that have not been provisioned yet."
+            )
+            raise typer.Exit()
 
-            if template_runner.is_approved(verb="destroy", resources=resources):
-                # deprovision the resources
-                template_runner.deprovision()
-                print_status(
-                    build_step_success_status("Destroying resources is complete!")
+        if template_runner.is_approved(verb="destroy", resources=resources):
+            # deprovision the resources
+            template_runner.deprovision()
+            print_status(build_step_success_status("Destroying resources is complete!"))
+        else:
+            print_status(
+                build_status(
+                    "You decided to cancel - your resources will remain active! If you change your mind, then run 'matcha destroy' again."
                 )
-            else:
-                print_status(
-                    build_status(
-                        "You decided to cancel - your resources will remain active! If you change your mind, then run 'matcha destroy' again."
-                    )
-                )
-                raise typer.Exit()
+            )
+            raise typer.Exit()

--- a/src/matcha_ml/cli/destroy.py
+++ b/src/matcha_ml/cli/destroy.py
@@ -11,8 +11,11 @@ from matcha_ml.runners import AzureRunner
 from matcha_ml.state import RemoteStateManager
 
 
-def destroy_resources() -> None:
+def destroy_resources(resources: list) -> None:
     """Destroy resources.
+
+    Args:
+        resources(list): the list of resources to be actioned by the verb to be provided to the user as a status message
 
     Raises:
         typer.Exit: Exit if matcha remote state has not been provisioned.
@@ -37,7 +40,7 @@ def destroy_resources() -> None:
                 )
                 raise typer.Exit()
 
-            if template_runner.is_approved(verb="destroy"):
+            if template_runner.is_approved(verb="destroy", resources=resources):
                 # deprovision the resources
                 template_runner.deprovision()
                 print_status(

--- a/src/matcha_ml/cli/destroy.py
+++ b/src/matcha_ml/cli/destroy.py
@@ -17,7 +17,7 @@ def destroy_resources(resources: List[Tuple[str, str]]) -> None:
     """Destroy resources.
 
     Args:
-        resources (list[str]): the list of resources to be actioned by the verb to be provided to the user as a status message
+        resources (List[Tuple[str,str]): the list of resources to be actioned by the verb to be provided to the user as a status message
 
     Raises:
         typer.Exit: Exit if matcha remote state has not been provisioned.

--- a/src/matcha_ml/cli/provision.py
+++ b/src/matcha_ml/cli/provision.py
@@ -5,7 +5,7 @@ from typing import Optional, Tuple
 import typer
 
 from matcha_ml.cli._validation import prefix_typer_callback, region_typer_callback
-from matcha_ml.cli.constants import STATE_RESOURCE_MSG
+from matcha_ml.cli.constants import RESOURCE_MSG
 from matcha_ml.cli.ui.print_messages import print_status
 from matcha_ml.cli.ui.status_message_builders import (
     build_status,
@@ -110,7 +110,7 @@ def provision_resources(
             azure_template.build_template(config, template, destination, verbose)
 
         # Initializes the infrastructure provisioning process.
-        if template_runner.is_approved(verb="provision", resources=STATE_RESOURCE_MSG):
+        if template_runner.is_approved(verb="provision", resources=RESOURCE_MSG):
             # provision resources by running the template
             template_runner.provision()
             print_status(build_step_success_status("Provisioning is complete!"))

--- a/src/matcha_ml/cli/provision.py
+++ b/src/matcha_ml/cli/provision.py
@@ -109,7 +109,23 @@ def provision_resources(
             azure_template.build_template(config, template, destination, verbose)
 
         # Initializes the infrastructure provisioning process.
-        if template_runner.is_approved(verb="provision"):
+        resources = [
+                ("Azure Kubernetes Service (AKS)", "A kubernetes cluster"),
+                (
+                    "Two Storage Containers",
+                    "A storage container for experiment tracking artifacts and a second for model training artifacts",
+                ),
+                (
+                    "Seldon Core",
+                    "A framework for model deployment on top of a kubernetes cluster",
+                ),
+                (
+                    "Azure Container Registry",
+                    "A container registry for storing docker images",
+                ),
+                ("ZenServer", "A zenml server required for remote orchestration"),
+            ]
+        if template_runner.is_approved(verb="provision", resources=resources):
             # provision resources by running the template
             template_runner.provision()
             print_status(build_step_success_status("Provisioning is complete!"))

--- a/src/matcha_ml/cli/provision.py
+++ b/src/matcha_ml/cli/provision.py
@@ -5,6 +5,7 @@ from typing import Optional, Tuple
 import typer
 
 from matcha_ml.cli._validation import prefix_typer_callback, region_typer_callback
+from matcha_ml.cli.constants import STATE_RESOURCE_MSG
 from matcha_ml.cli.ui.print_messages import print_status
 from matcha_ml.cli.ui.status_message_builders import (
     build_status,
@@ -109,23 +110,7 @@ def provision_resources(
             azure_template.build_template(config, template, destination, verbose)
 
         # Initializes the infrastructure provisioning process.
-        resources = [
-                ("Azure Kubernetes Service (AKS)", "A kubernetes cluster"),
-                (
-                    "Two Storage Containers",
-                    "A storage container for experiment tracking artifacts and a second for model training artifacts",
-                ),
-                (
-                    "Seldon Core",
-                    "A framework for model deployment on top of a kubernetes cluster",
-                ),
-                (
-                    "Azure Container Registry",
-                    "A container registry for storing docker images",
-                ),
-                ("ZenServer", "A zenml server required for remote orchestration"),
-            ]
-        if template_runner.is_approved(verb="provision", resources=resources):
+        if template_runner.is_approved(verb="provision", resources=STATE_RESOURCE_MSG):
             # provision resources by running the template
             template_runner.provision()
             print_status(build_step_success_status("Provisioning is complete!"))

--- a/src/matcha_ml/runners/azure_runner.py
+++ b/src/matcha_ml/runners/azure_runner.py
@@ -1,9 +1,10 @@
 """Run terraform templates to provision and deprovision resources."""
 import json
-import typer
 import uuid
 from collections import defaultdict
 from typing import Dict, Tuple
+
+import typer
 
 from matcha_ml.cli.ui.emojis import Emojis
 from matcha_ml.cli.ui.print_messages import (
@@ -16,8 +17,8 @@ from matcha_ml.cli.ui.resource_message_builders import (
     hide_sensitive_in_output,
 )
 from matcha_ml.cli.ui.status_message_builders import (
-    build_status,
     build_resource_confirmation,
+    build_status,
 )
 from matcha_ml.errors import MatchaInputError
 from matcha_ml.runners.base_runner import BaseRunner
@@ -39,7 +40,7 @@ class AzureRunner(BaseRunner):
         """Initialize AzureRunner class."""
         super().__init__()
 
-    def is_approved(self, verb: str, resources: list[str]) -> bool:
+    def is_approved(self, verb: str, resources: list[tuple[str, str]]) -> bool:
         """Get approval from user to modify resources on cloud.
 
         Args:

--- a/src/matcha_ml/runners/azure_runner.py
+++ b/src/matcha_ml/runners/azure_runner.py
@@ -125,39 +125,6 @@ class AzureRunner(BaseRunner):
             resources_json = dict_to_json(resources_dict)
             print_json(resources_json)
 
-    # def is_approved(self, verb: str) -> bool:
-    #     """Get approval from user to modify resources on cloud.
-
-    #     Args:
-    #         verb (str): the verb to use in the approval message.
-
-    #     Returns:
-    #         bool: True if user approves, False otherwise.
-    #     """
-    #     summary_message = build_resource_confirmation(
-    #         header=f"The following resources will be {verb}ed",
-    #         resources=[
-    #             ("Azure Kubernetes Service (AKS)", "A kubernetes cluster"),
-    #             (
-    #                 "Two Storage Containers",
-    #                 "A storage container for experiment tracking artifacts and a second for model training artifacts",
-    #             ),
-    #             (
-    #                 "Seldon Core",
-    #                 "A framework for model deployment on top of a kubernetes cluster",
-    #             ),
-    #             (
-    #                 "Azure Container Registry",
-    #                 "A container registry for storing docker images",
-    #             ),
-    #             ("ZenServer", "A zenml server required for remote orchestration"),
-    #         ],
-    #         footer=f"{verb.capitalize()}ing the resources may take approximately 20 minutes. May we suggest you grab a cup of {Emojis.MATCHA.value}?",
-    #     )
-
-    #     print_status(summary_message)
-    #     return typer.confirm(f"Are you happy for '{verb}' to run?")
-
     def _write_outputs_state_cloud_only(self) -> None:
         """Write the outputs of the Terraform deployment to the state JSON file."""
         with open(self.state_file) as f:

--- a/src/matcha_ml/runners/azure_runner.py
+++ b/src/matcha_ml/runners/azure_runner.py
@@ -2,7 +2,7 @@
 import json
 import uuid
 from collections import defaultdict
-from typing import Dict, Tuple
+from typing import Dict, List, Tuple
 
 import typer
 
@@ -40,7 +40,7 @@ class AzureRunner(BaseRunner):
         """Initialize AzureRunner class."""
         super().__init__()
 
-    def is_approved(self, verb: str, resources: list[tuple[str, str]]) -> bool:
+    def is_approved(self, verb: str, resources: List[Tuple[str, str]]) -> bool:
         """Get approval from user to modify resources on cloud.
 
         Args:

--- a/src/matcha_ml/runners/azure_runner.py
+++ b/src/matcha_ml/runners/azure_runner.py
@@ -39,33 +39,19 @@ class AzureRunner(BaseRunner):
         """Initialize AzureRunner class."""
         super().__init__()
 
-    def is_approved(self, verb: str) -> bool:
+    def is_approved(self, verb: str, resources: list[str]) -> bool:
         """Get approval from user to modify resources on cloud.
 
         Args:
             verb (str): the verb to use in the approval message.
+            resources(list): the list of resources to be actioned by the verb to be provided to the user as a status message
 
         Returns:
             bool: True if user approves, False otherwise.
         """
         summary_message = build_resource_confirmation(
             header=f"The following resources will be {verb}ed",
-            resources=[
-                ("Azure Kubernetes Service (AKS)", "A kubernetes cluster"),
-                (
-                    "Two Storage Containers",
-                    "A storage container for experiment tracking artifacts and a second for model training artifacts",
-                ),
-                (
-                    "Seldon Core",
-                    "A framework for model deployment on top of a kubernetes cluster",
-                ),
-                (
-                    "Azure Container Registry",
-                    "A container registry for storing docker images",
-                ),
-                ("ZenServer", "A zenml server required for remote orchestration"),
-            ],
+            resources=resources,
             footer=f"{verb.capitalize()}ing the resources may take approximately 20 minutes. May we suggest you grab a cup of {Emojis.MATCHA.value}?",
         )
 
@@ -138,38 +124,38 @@ class AzureRunner(BaseRunner):
             resources_json = dict_to_json(resources_dict)
             print_json(resources_json)
 
-    def is_approved(self, verb: str) -> bool:
-        """Get approval from user to modify resources on cloud.
+    # def is_approved(self, verb: str) -> bool:
+    #     """Get approval from user to modify resources on cloud.
 
-        Args:
-            verb (str): the verb to use in the approval message.
+    #     Args:
+    #         verb (str): the verb to use in the approval message.
 
-        Returns:
-            bool: True if user approves, False otherwise.
-        """
-        summary_message = build_resource_confirmation(
-            header=f"The following resources will be {verb}ed",
-            resources=[
-                ("Azure Kubernetes Service (AKS)", "A kubernetes cluster"),
-                (
-                    "Two Storage Containers",
-                    "A storage container for experiment tracking artifacts and a second for model training artifacts",
-                ),
-                (
-                    "Seldon Core",
-                    "A framework for model deployment on top of a kubernetes cluster",
-                ),
-                (
-                    "Azure Container Registry",
-                    "A container registry for storing docker images",
-                ),
-                ("ZenServer", "A zenml server required for remote orchestration"),
-            ],
-            footer=f"{verb.capitalize()}ing the resources may take approximately 20 minutes. May we suggest you grab a cup of {Emojis.MATCHA.value}?",
-        )
+    #     Returns:
+    #         bool: True if user approves, False otherwise.
+    #     """
+    #     summary_message = build_resource_confirmation(
+    #         header=f"The following resources will be {verb}ed",
+    #         resources=[
+    #             ("Azure Kubernetes Service (AKS)", "A kubernetes cluster"),
+    #             (
+    #                 "Two Storage Containers",
+    #                 "A storage container for experiment tracking artifacts and a second for model training artifacts",
+    #             ),
+    #             (
+    #                 "Seldon Core",
+    #                 "A framework for model deployment on top of a kubernetes cluster",
+    #             ),
+    #             (
+    #                 "Azure Container Registry",
+    #                 "A container registry for storing docker images",
+    #             ),
+    #             ("ZenServer", "A zenml server required for remote orchestration"),
+    #         ],
+    #         footer=f"{verb.capitalize()}ing the resources may take approximately 20 minutes. May we suggest you grab a cup of {Emojis.MATCHA.value}?",
+    #     )
 
-        print_status(summary_message)
-        return typer.confirm(f"Are you happy for '{verb}' to run?")
+    #     print_status(summary_message)
+    #     return typer.confirm(f"Are you happy for '{verb}' to run?")
 
     def _write_outputs_state_cloud_only(self) -> None:
         """Write the outputs of the Terraform deployment to the state JSON file."""

--- a/src/matcha_ml/runners/base_runner.py
+++ b/src/matcha_ml/runners/base_runner.py
@@ -136,10 +136,9 @@ class BaseRunner:
 
             if ret_code != 0:
                 raise MatchaTerraformError(tf_error=err)
-
         print_status(
             build_substep_success_status(
-                f"{Emojis.CHECKMARK.value} Your environment has been provisioned!\n"
+                f"{Emojis.CHECKMARK.value} Resources for matcha to work have been provisioned!\n"
             )
         )
 

--- a/src/matcha_ml/state/remote_state_manager.py
+++ b/src/matcha_ml/state/remote_state_manager.py
@@ -191,7 +191,6 @@ class RemoteStateManager:
 
         account_name, container_name, resource_group_name = template_runner.provision()
         self._write_matcha_config(account_name, container_name, resource_group_name)
-        # rpd2
         print_status(
             build_step_success_status(
                 "Provisioning of the remote state storage is complete!"

--- a/src/matcha_ml/state/remote_state_manager.py
+++ b/src/matcha_ml/state/remote_state_manager.py
@@ -191,8 +191,8 @@ class RemoteStateManager:
 
         account_name, container_name, resource_group_name = template_runner.provision()
         self._write_matcha_config(account_name, container_name, resource_group_name)
-
-        print_status(build_step_success_status("Provisioning is complete!"))
+# rpd2
+        print_status(build_step_success_status("Provisioning of the remote state storage is complete!"))
         print()
 
     def deprovision_remote_state(self) -> None:

--- a/src/matcha_ml/state/remote_state_manager.py
+++ b/src/matcha_ml/state/remote_state_manager.py
@@ -191,8 +191,12 @@ class RemoteStateManager:
 
         account_name, container_name, resource_group_name = template_runner.provision()
         self._write_matcha_config(account_name, container_name, resource_group_name)
-# rpd2
-        print_status(build_step_success_status("Provisioning of the remote state storage is complete!"))
+        # rpd2
+        print_status(
+            build_step_success_status(
+                "Provisioning of the remote state storage is complete!"
+            )
+        )
         print()
 
     def deprovision_remote_state(self) -> None:
@@ -203,7 +207,7 @@ class RemoteStateManager:
         template_runner.deprovision()
         self._remove_matcha_config()
         print_status(
-            build_step_success_status("Destroying remote state management is complete!")
+            build_step_success_status("Destroying Matcha resources is complete!")
         )
 
     def _write_matcha_config(

--- a/src/matcha_ml/state/remote_state_manager.py
+++ b/src/matcha_ml/state/remote_state_manager.py
@@ -192,9 +192,7 @@ class RemoteStateManager:
         account_name, container_name, resource_group_name = template_runner.provision()
         self._write_matcha_config(account_name, container_name, resource_group_name)
         print_status(
-            build_step_success_status(
-                "Provisioning of the remote state storage is complete!"
-            )
+            build_step_success_status("Provisioning Matcha reources is complete!")
         )
         print()
 

--- a/src/matcha_ml/state/remote_state_manager.py
+++ b/src/matcha_ml/state/remote_state_manager.py
@@ -8,6 +8,7 @@ from azure.core.exceptions import ResourceExistsError
 from dataclasses_json import DataClassJsonMixin
 
 from matcha_ml.cli.ui.print_messages import print_error, print_status
+from matcha_ml.cli.ui.spinner import Spinner
 from matcha_ml.cli.ui.status_message_builders import (
     build_step_success_status,
     build_warning_status,
@@ -275,11 +276,13 @@ class RemoteStateManager:
         Downloads the state before executing the code.
         Upload the state when context is finished.
         """
-        self.download(os.getcwd())
+        with Spinner("Downloading Matcha resources..."):
+            self.download(os.getcwd())
 
         yield None
 
-        self.upload(os.path.join(".matcha", "infrastructure"))
+        with Spinner("Uploading Matcha resources..."):
+            self.upload(os.path.join(".matcha", "infrastructure"))
 
     def lock(self) -> None:
         """Lock remote state.

--- a/src/matcha_ml/state/remote_state_manager.py
+++ b/src/matcha_ml/state/remote_state_manager.py
@@ -8,7 +8,6 @@ from azure.core.exceptions import ResourceExistsError
 from dataclasses_json import DataClassJsonMixin
 
 from matcha_ml.cli.ui.print_messages import print_error, print_status
-from matcha_ml.cli.ui.spinner import Spinner
 from matcha_ml.cli.ui.status_message_builders import (
     build_step_success_status,
     build_warning_status,
@@ -276,13 +275,11 @@ class RemoteStateManager:
         Downloads the state before executing the code.
         Upload the state when context is finished.
         """
-        with Spinner("Downloading Matcha resources..."):
-            self.download(os.getcwd())
+        self.download(os.getcwd())
 
         yield None
 
-        with Spinner("Uploading Matcha resources..."):
-            self.upload(os.path.join(".matcha", "infrastructure"))
+        self.upload(os.path.join(".matcha", "infrastructure"))
 
     def lock(self) -> None:
         """Lock remote state.

--- a/tests/test_runners/test_azure_runner.py
+++ b/tests/test_runners/test_azure_runner.py
@@ -170,10 +170,10 @@ def test_is_approved(template_runner: AzureRunner):
     """
     with mock.patch("typer.confirm") as mock_confirm:
         mock_confirm.return_value = True
-        assert template_runner.is_approved("provision")
+        assert template_runner.is_approved("provision", [])
 
         mock_confirm.return_value = False
-        assert not template_runner.is_approved("provision")
+        assert not template_runner.is_approved("provision", [])
 
 
 def test_write_outputs_state(

--- a/tests/test_runners/test_base_runner.py
+++ b/tests/test_runners/test_base_runner.py
@@ -118,7 +118,7 @@ def test_apply_terraform(capsys: SysCapture):
     """
     template_runner = BaseRunner()
     template_runner.tfs.apply = MagicMock(return_value=(0, "", ""))
-    expected = "Your environment has been provisioned!"
+    expected = "Resources for matcha to work have been provisioned!"
 
     template_runner._apply_terraform()
     captured = capsys.readouterr()

--- a/tests/test_state/test_remote_state_manager.py
+++ b/tests/test_state/test_remote_state_manager.py
@@ -232,7 +232,7 @@ def test_deprovision_remote_state(
 
         captured = capsys.readouterr()
 
-        expected_output = "Destroying remote state management is complete!"
+        expected_output = "Destroying Matcha resources is complete!"
 
         template_runner = RemoteStateRunner()
         template_runner.deprovision.assert_called()
@@ -467,7 +467,7 @@ def test_is_state_provisioned_returns_false_when_resource_group_does_not_exist(
     # Make sure the check for the storage container is not called
     mock_azure_storage_instance.container_exists.assert_not_called()
 
- 
+
 def test_remove_matcha_config(capsys: SysCapture):
     """Test the functionality of the `remove_matcha_config` function by verifying if it correctly catches the "File not found" error and throws the expected error message.
 


### PR DESCRIPTION
This pull request implements the following changes to the UI to account for the addition of remote state:

- Updates the console message once remote state resources have been provisioned.
- Differentiates the resources to be destroyed between `matcha destroy` and `matcha destroy full`.
- Adds a progress spinner for the `destroy` cli command.
- Adds a warning message relating to orphaned cloud assets on 'matcha destroy'.
- Updates the status message once remote state is destroyed.

This pull request was created to ensure that the UI messaging to the user remains relevant given the changes in provisioning and destroying infrastructure following the introduction of remote state.

Most of the changes have been achieved through changes to static messages, or through the reuse of UI components such as warning messages or spinners. The differentiation of resource confirmations was implemented by moving the definition of resources to be confirmed to the user out of the `AzureRunner` and into the cli module.

## Checklist

Please ensure you have done the following:

* [x] I have read the [CONTRIBUTING](https://github.com/fuzzylabs/matcha/blob/main/CONTRIBUTING.md) guide.
* [ ] I have updated the documentation if required.
* [ ] I have added tests which cover my changes.

## Type of change

Tick all those that apply:

* [ ] Bug Fix (non-breaking change, fixing an issue)
* [ ] New feature (non-breaking change to add functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [X] Other (add details above)
