### PR TITLE
[RPD-234] [BUG] Handle existing matcha configuration better

### DIFF
--- a/src/matcha_ml/cli/provision.py
+++ b/src/matcha_ml/cli/provision.py
@@ -75,6 +75,22 @@ def provision_resources(
     """
     remote_state_manager = RemoteStateManager()
 
+    if remote_state_manager.is_state_stale():
+        print(
+            "Matcha has detected a stale state file. This means that your local configuration is out of sync with the remote state, the resource group may have been removed."
+        )
+        remove_local_config = typer.confirm(
+            "Do you want to remove the existing local config and continue?"
+        )
+        if not remove_local_config:
+            raise typer.Exit()
+        remote_state_manager.remove_config_file()
+        remote_state_manager.azure_storage._sync_local(
+            os.path.join(os.getcwd(), ".matcha")
+        )
+        print("Synced local files.")
+        remote_state_manager = RemoteStateManager()
+
     # Check whether remote state storage has been provisioned
     if not remote_state_manager.is_state_provisioned():
         location, prefix, _ = fill_provision_variables(

--- a/src/matcha_ml/cli/provision.py
+++ b/src/matcha_ml/cli/provision.py
@@ -72,6 +72,7 @@ def provision_resources(
 
     Raises:
         typer.Exit: if approval is not given by user.
+        typer.Exit: if approval for removing a stale state is not given by user.
     """
     remote_state_manager = RemoteStateManager()
 
@@ -85,7 +86,6 @@ def provision_resources(
         if not remove_local_config:
             raise typer.Exit()
         remote_state_manager.remove_matcha_config()
-        print("Synced local state config.")
         # Re-initialise remote state manager with empty state file
         remote_state_manager = RemoteStateManager()
 

--- a/src/matcha_ml/cli/provision.py
+++ b/src/matcha_ml/cli/provision.py
@@ -83,11 +83,12 @@ def provision_resources(
                 "Matcha has detected a stale state file. This means that your local configuration is out of sync with the remote state, the resource group may have been removed."
             )
         )
-        remove_local_config = typer.confirm(
+
+        if not typer.confirm(
             "Do you want to remove the existing local config and continue?"
-        )
-        if not remove_local_config:
+        ):
             raise typer.Exit()
+
         remote_state_manager.remove_matcha_config()
         # Re-initialise remote state manager with empty state file
         remote_state_manager = RemoteStateManager()

--- a/src/matcha_ml/cli/provision.py
+++ b/src/matcha_ml/cli/provision.py
@@ -84,11 +84,9 @@ def provision_resources(
         )
         if not remove_local_config:
             raise typer.Exit()
-        remote_state_manager.remove_config_file()
-        remote_state_manager.azure_storage._sync_local(
-            os.path.join(os.getcwd(), ".matcha")
-        )
-        print("Synced local files.")
+        remote_state_manager.remove_matcha_config()
+        print("Synced local state config.")
+        # Re-initialise remote state manager with empty state file
         remote_state_manager = RemoteStateManager()
 
     # Check whether remote state storage has been provisioned

--- a/src/matcha_ml/cli/provision.py
+++ b/src/matcha_ml/cli/provision.py
@@ -78,8 +78,10 @@ def provision_resources(
     remote_state_manager = RemoteStateManager()
 
     if remote_state_manager.is_state_stale():
-        build_warning_status(
-            "Matcha has detected a stale state file. This means that your local configuration is out of sync with the remote state, the resource group may have been removed."
+        print_status(
+            build_warning_status(
+                "Matcha has detected a stale state file. This means that your local configuration is out of sync with the remote state, the resource group may have been removed."
+            )
         )
         remove_local_config = typer.confirm(
             "Do you want to remove the existing local config and continue?"

--- a/src/matcha_ml/cli/provision.py
+++ b/src/matcha_ml/cli/provision.py
@@ -9,6 +9,7 @@ from matcha_ml.cli.ui.print_messages import print_status
 from matcha_ml.cli.ui.status_message_builders import (
     build_status,
     build_step_success_status,
+    build_warning_status,
 )
 from matcha_ml.runners import AzureRunner
 from matcha_ml.state import RemoteStateManager
@@ -77,7 +78,7 @@ def provision_resources(
     remote_state_manager = RemoteStateManager()
 
     if remote_state_manager.is_state_stale():
-        print(
+        build_warning_status(
             "Matcha has detected a stale state file. This means that your local configuration is out of sync with the remote state, the resource group may have been removed."
         )
         remove_local_config = typer.confirm(

--- a/src/matcha_ml/state/remote_state_manager.py
+++ b/src/matcha_ml/state/remote_state_manager.py
@@ -160,6 +160,31 @@ class RemoteStateManager:
 
         return True
 
+    def is_state_stale(self) -> bool:
+        """Check if remote state has been destroyed.
+
+        Returns:
+            bool: True, if state is stale
+        """
+        # No config file means not stale
+        if not self._configuration_file_exists():
+            return False
+
+        # Config file and no resource group means it is stale
+        if not self._resource_group_exists():
+            return True
+
+        # Config, resource group and bucket exists means not state
+        if self._bucket_exists(self.configuration.remote_state_bucket.container_name):
+            return False
+
+        return True
+
+    def remove_config_file(self) -> None:
+        """Remove config file if it exists."""
+        if self._configuration_file_exists():
+            os.remove(self.config_path)
+
     def provision_remote_state(
         self, location: str, prefix: str, verbose: Optional[bool] = False
     ) -> None:

--- a/src/matcha_ml/state/remote_state_manager.py
+++ b/src/matcha_ml/state/remote_state_manager.py
@@ -166,24 +166,9 @@ class RemoteStateManager:
         Returns:
             bool: True, if state is stale
         """
-        # No config file means not stale
-        if not self._configuration_file_exists():
-            return False
-
-        # Config file and no resource group means it is stale
-        if not self._resource_group_exists():
-            return True
-
-        # Config, resource group and bucket exists means not state
-        if self._bucket_exists(self.configuration.remote_state_bucket.container_name):
-            return False
-
-        return True
-
-    def remove_config_file(self) -> None:
-        """Remove config file if it exists."""
-        if self._configuration_file_exists():
-            os.remove(self.config_path)
+        return bool(
+            self._configuration_file_exists() and not self._resource_group_exists()
+        )
 
     def provision_remote_state(
         self, location: str, prefix: str, verbose: Optional[bool] = False
@@ -226,7 +211,7 @@ class RemoteStateManager:
         template_runner = RemoteStateRunner()
 
         template_runner.deprovision()
-        self._remove_matcha_config()
+        self.remove_matcha_config()
         print_status(
             build_step_success_status("Destroying remote state management is complete!")
         )
@@ -261,7 +246,7 @@ class RemoteStateManager:
             )
         )
 
-    def _remove_matcha_config(self) -> None:
+    def remove_matcha_config(self) -> None:
         """Remove the matcha.config.json file after destroy full is run."""
         try:
             os.remove(self.config_path)

--- a/tests/test_cli/test_provision.py
+++ b/tests/test_cli/test_provision.py
@@ -633,14 +633,13 @@ def test_cli_provision_command_with_provisioned_resources(
 
 
 def test_remote_state_removed_when_remote_state_is_stale_with_user_confirmation(
-    runner: CliRunner, matcha_testing_directory: str, mock_use_lock: MagicMock
+    runner: CliRunner, matcha_testing_directory: str
 ):
-    """_summary_.
+    """Tests that the matcha.config.json file is removed when the remote state is stale and the user confirms removal.
 
     Args:
-        runner (CliRunner): _description_
-        matcha_testing_directory (str): _description_
-        mock_use_lock (MagicMock): _description_
+        runner (CliRunner): typer CLI runner
+        matcha_testing_directory (str): temporary working directory
     """
     os.chdir(matcha_testing_directory)
     matcha_config_file_path = os.path.join(


### PR DESCRIPTION
When a user deletes a resource group manually or uses a shared state and another person has run `matcha destroy full` the user would be left with an out-of-sync config file. This would cause errors when running `matcha provision` again as the specified resource group would not exist.

This PR aims to fix this by checking if the state is stale (the user has a remote state config file but the resource group does not exist) and based on the user's decision, either:

1. Removes the remote config file and continue with a new deployment
2. Or the user can stop the command at this point


## Checklist

Please ensure you have done the following:

* [x] I have read the [CONTRIBUTING](https://github.com/fuzzylabs/matcha/blob/main/CONTRIBUTING.md) guide.
* [x] I have updated the documentation if required.
* [x] I have added tests which cover my changes.

## Type of change

Tick all those that apply:

* [x] Bug Fix (non-breaking change, fixing an issue)
* [ ] New feature (non-breaking change to add functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Other (add details above)
