### PR TITLE
[RPD-237] Add a check for the user and environment uuid

### DIFF
--- a/src/matcha_ml/services/_validation.py
+++ b/src/matcha_ml/services/_validation.py
@@ -23,7 +23,7 @@ def _check_uuid(uuid: str) -> bool:
         str(UUID(uuid, version=UUID_VERSION))
     except ValueError:
         raise MatchaError(
-            "Error - the user or environment unique identifier is maliformed."
+            "Error - the user or environment unique identifier is malformed."
         )
 
     return True

--- a/src/matcha_ml/services/_validation.py
+++ b/src/matcha_ml/services/_validation.py
@@ -1,0 +1,29 @@
+"""Common validation functions for the services."""
+
+from uuid import UUID
+
+from matcha_ml.errors import MatchaError
+
+UUID_VERSION = 4
+
+
+def _check_uuid(uuid: str) -> bool:
+    """Checks whether a string is a valid UUID.
+
+    Args:
+        uuid (str): the possible UUID to check.
+
+    Raises:
+        MatchaError: if the uuid parameter cannot be parsed as a UUID object.
+
+    Returns:
+        bool: True when the UUID is valid.
+    """
+    try:
+        str(UUID(uuid, version=UUID_VERSION))
+    except ValueError:
+        raise MatchaError(
+            "Error - the user or environment unique identifier is maliformed."
+        )
+
+    return True

--- a/src/matcha_ml/services/analytics_service.py
+++ b/src/matcha_ml/services/analytics_service.py
@@ -9,6 +9,8 @@ from typing import Any, Callable, Optional
 
 from segment import analytics
 
+from matcha_ml.errors import MatchaError
+from matcha_ml.services._validation import _check_uuid
 from matcha_ml.services.global_parameters_service import GlobalParameters
 from matcha_ml.state import MatchaStateService
 
@@ -60,6 +62,11 @@ def track(event_name: AnalyticsEvent) -> Callable[..., Any]:
                     matcha_state_id_dict = matcha_state_service.state_file.get("id")
                     if matcha_state_id_dict is not None:
                         matcha_state_uuid = matcha_state_id_dict.get("matcha_uuid")
+
+                        try:
+                            _check_uuid(str(matcha_state_uuid))
+                        except MatchaError as me:
+                            raise MatchaError(str(me))
 
                 analytics.track(
                     global_params.user_id,

--- a/src/matcha_ml/services/analytics_service.py
+++ b/src/matcha_ml/services/analytics_service.py
@@ -41,7 +41,15 @@ def track(event_name: AnalyticsEvent) -> Callable[..., Any]:
 
         @functools.wraps(func)
         def inner(*args: Any, **kwargs: Any) -> Any:
-            """Inner decorator function."""
+            """The internal function that does the logic of capturing analytics and executing the function that's being wrapped.
+
+            Raises:
+                MatchaError: Raised when the matcha_state_uuid is invalid.
+                error_code: Raised when an error occurs when running the wrapped function.
+
+            Returns:
+                Any: the result of the wrapped function.
+            """
             global_params = GlobalParameters()
 
             if not global_params.analytics_opt_out:

--- a/src/matcha_ml/services/global_parameters_service.py
+++ b/src/matcha_ml/services/global_parameters_service.py
@@ -1,7 +1,7 @@
 """Global parameter service for creating and modifying a users global config files."""
 import os
-import uuid
 from typing import Any, Dict, Optional
+from uuid import uuid4
 
 import yaml
 
@@ -36,7 +36,11 @@ class GlobalParameters:
         return cls._instance
 
     def _read_global_config(self) -> None:
-        """Reads the config yaml file containing the global parameters."""
+        """Reads the config yaml file containing the global parameters.
+
+        Raises:
+            MatchaError: Raised when the user_id uuid is an invalid uuid.
+        """
         with open(self.default_config_file_path) as file:
             yaml_data = yaml.safe_load(file)
 
@@ -86,7 +90,7 @@ class GlobalParameters:
             str: Unqiue user ID string
         """
         if self._user_id is None:
-            self._user_id = str(uuid.uuid4())
+            self._user_id = str(uuid4())
         return self._user_id
 
     @property

--- a/src/matcha_ml/services/global_parameters_service.py
+++ b/src/matcha_ml/services/global_parameters_service.py
@@ -5,7 +5,8 @@ from typing import Any, Dict, Optional
 
 import yaml
 
-from matcha_ml.errors import MatchaPermissionError
+from matcha_ml.errors import MatchaError, MatchaPermissionError
+from matcha_ml.services._validation import _check_uuid
 
 
 class GlobalParameters:
@@ -38,6 +39,11 @@ class GlobalParameters:
         """Reads the config yaml file containing the global parameters."""
         with open(self.default_config_file_path) as file:
             yaml_data = yaml.safe_load(file)
+
+        try:
+            _check_uuid(yaml_data.get("user_id"))
+        except MatchaError as me:
+            raise MatchaError(str(me))
 
         self._user_id = yaml_data.get("user_id")
         self._analytics_opt_out = yaml_data.get("analytics_opt_out")

--- a/tests/test_services/__init__.py
+++ b/tests/test_services/__init__.py
@@ -1,0 +1,1 @@
+"""An initialiser for the module to ensure differentiation between tests with the same name."""

--- a/tests/test_services/conftest.py
+++ b/tests/test_services/conftest.py
@@ -1,0 +1,21 @@
+"""Configuration tests for the test_services module."""
+import random
+import uuid
+
+import pytest
+
+
+@pytest.fixture(scope="module", autouse=True)
+def random_state():
+    """A fixture to ensure the random state is fixed for the tests."""
+    random.seed(42)
+
+
+@pytest.fixture
+def uuid_for_testing() -> uuid.UUID:
+    """A random UUID4 that can be used as a fixture in the tests.
+
+    Returns:
+        uuid.UUID: a UUID4 which remains the same across tests.
+    """
+    return uuid.UUID(int=random.getrandbits(128), version=4)

--- a/tests/test_services/conftest.py
+++ b/tests/test_services/conftest.py
@@ -4,6 +4,8 @@ import uuid
 
 import pytest
 
+UUID_VERSION = 4
+
 
 @pytest.fixture(scope="module", autouse=True)
 def random_state():
@@ -18,4 +20,4 @@ def uuid_for_testing() -> uuid.UUID:
     Returns:
         uuid.UUID: a UUID4 which remains the same across tests.
     """
-    return uuid.UUID(int=random.getrandbits(128), version=4)
+    return uuid.UUID(int=random.getrandbits(128), version=UUID_VERSION)

--- a/tests/test_services/test_analytics_service.py
+++ b/tests/test_services/test_analytics_service.py
@@ -13,11 +13,12 @@ GLOBAL_PARAMETER_SERVICE_FUNCTION_STUB = (
 
 
 @pytest.fixture(autouse=True)
-def mocked_global_parameters_service(matcha_testing_directory):
+def mocked_global_parameters_service(matcha_testing_directory, uuid_for_testing):
     """Mocked global parameters service.
 
     Args:
         matcha_testing_directory (str): Temporary directory for testing.
+        uuid_for_testing (uuid.UUID): a UUID which acts as a mock for the user_id
 
     Yields:
         GlobalParameters: GlobalParameters object with mocked properties.
@@ -32,13 +33,13 @@ def mocked_global_parameters_service(matcha_testing_directory):
         file_path.return_value = str(
             os.path.join(str(matcha_testing_directory), ".matcha-ml", "config.yaml")
         )
-        user_id.return_value = "TestUserID"
+        user_id.return_value = str(uuid_for_testing)
 
         yield GlobalParameters()
 
 
 def test_segment_track_recieves_the_correct_arguments(
-    runner, matcha_testing_directory, mocked_segment_track_decorator
+    runner, matcha_testing_directory, mocked_segment_track_decorator, uuid_for_testing
 ):
     """Test no the Segment track function recieves the expected arguments when a user is opted in to analytics.
 
@@ -46,6 +47,7 @@ def test_segment_track_recieves_the_correct_arguments(
         runner (CliRunner): typer CLI runner
         matcha_testing_directory (str): temporary working directory.
         mocked_segment_track_decorator (MagicMock): mocked Segment track call found in 'matcha_ml.services.analytics_service.analytics.track'
+        uuid_for_testing (uuid.UUID): a UUID which acts as a mock for the matcha_state_id
     """
     os.chdir(matcha_testing_directory)
 
@@ -61,7 +63,7 @@ def test_segment_track_recieves_the_correct_arguments(
 
     tracked_arguments = mocked_segment_track_decorator.call_args.args
     # Check that the Segment track arguments are as expected
-    assert "TestUserID" in tracked_arguments
+    assert str(uuid_for_testing) in tracked_arguments
     assert "destroy" in tracked_arguments
     assert {
         "time_taken",

--- a/tests/test_services/test_global_parameters_service.py
+++ b/tests/test_services/test_global_parameters_service.py
@@ -60,18 +60,19 @@ def test_new_config_file_creation(matcha_testing_directory):
         assert os.path.exists(config_file_path)
 
 
-def test_existing_config_file(matcha_testing_directory):
+def test_existing_config_file(matcha_testing_directory, uuid_for_testing):
     """Tests that the class variables are updated when there is an existing config file.
 
     Args:
         matcha_testing_directory (str): Mock testing directory location for the config file to be located
+        uuid_for_testing (uuid.UUID): a UUID which acts as a mock for the user_id
     """
     config_file_path = os.path.join(
         matcha_testing_directory, ".matcha-ml", "config.yaml"
     )
 
     data = {
-        "user_id": "TestUserID",
+        "user_id": str(uuid_for_testing),
         "analytics_opt_out": False,
     }
 
@@ -90,10 +91,10 @@ def test_existing_config_file(matcha_testing_directory):
 
         config_instance = GlobalParameters()
         assert config_instance.config_file == {
-            "user_id": "TestUserID",
+            "user_id": str(uuid_for_testing),
             "analytics_opt_out": False,
         }
-        assert config_instance.user_id == "TestUserID"
+        assert config_instance.user_id == str(uuid_for_testing)
         assert config_instance.analytics_opt_out is False
 
 

--- a/tests/test_services/test_validation.py
+++ b/tests/test_services/test_validation.py
@@ -1,0 +1,22 @@
+"""Tests for services._validation."""
+from uuid import UUID
+
+import pytest
+
+from matcha_ml.errors import MatchaError
+from matcha_ml.services._validation import _check_uuid
+
+
+def test_valid_uuid(uuid_for_testing: UUID):
+    """Test that when a valid uuid is passed, the check passes.
+
+    Args:
+        uuid_for_testing (UUID): a UUID created for testing purposes.
+    """
+    assert _check_uuid(str(uuid_for_testing))
+
+
+def test_invalid_uuid():
+    """Test that when an invalid UUID is passed, the check fails and an exception is raised."""
+    with pytest.raises(MatchaError):
+        _check_uuid("this-is-not-a-uuid")


### PR DESCRIPTION
This PR introduces a validation check for the uuid's that we're generating (one for the user and one for the matcha environment). The check is simple, if the parsed ID can be used to create a `UUID` object then we know it's a valid UUID.

We're introducing this check as there's a possibly a user could inadvertently modify the two ids, which is something that want to avoid for obvious reasons.

If the potential uuid can be parsed as a UUID object, then the function returns `True`, otherwise an error is raised.

These checks have been added into the code where relevant and tests have been updated accordingly, more precisely:

* A `_check_uuid` function has been introduced in a new `_validation` file under `services`.
* Checks have been added to the `analytics_service` and `global_parameter_service`.
* A `conftest` has been added to the `test_services` module to generate a uuid for the relevant tests.
* Finally, the tests that make use of a uuid have been updated to use the above uuid.

## Checklist

Please ensure you have done the following:

* [x] I have read the [CONTRIBUTING](https://github.com/fuzzylabs/matcha/blob/main/CONTRIBUTING.md) guide.
* [ ] I have updated the documentation if required.
* [x] I have added tests which cover my changes.

## Type of change

Tick all those that apply:

* [ ] Bug Fix (non-breaking change, fixing an issue)
* [x] New feature (non-breaking change to add functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Other (add details above)
