### PR TITLE
[RPD-226] Download `.matcha` from remote state storage if state file hash mismatch state when `matcha get` command is run

### DIFF
--- a/src/matcha_ml/cli/cli.py
+++ b/src/matcha_ml/cli/cli.py
@@ -82,8 +82,8 @@ def get(
         show_sensitive (Optional[bool]): show hidden sensitive resource values when True. Defaults to False.
 
     Raises:
-        Exit: Exit if matcha remote state has not been provisioned.
         Exit: Exit if matcha.state file does not exist.
+        Exit: Exit if matcha remote state has not been provisioned.
         Exit: Exit if resource type or property does not exist in matcha.state.
     """
     matcha_state_path = os.path.join(".matcha", "infrastructure", "matcha.state")

--- a/src/matcha_ml/cli/cli.py
+++ b/src/matcha_ml/cli/cli.py
@@ -1,4 +1,5 @@
 """Matcha CLI."""
+import os
 from typing import Optional
 
 import typer
@@ -85,7 +86,20 @@ def get(
         Exit: Exit if matcha.state file does not exist.
         Exit: Exit if resource type or property does not exist in matcha.state.
     """
+    matcha_state_path = os.path.join(".matcha", "infrastructure", "matcha.state")
     remote_state = RemoteStateManager()
+
+    try:
+        local_hash = core.get_local_state_hash(matcha_state_path)
+    except MatchaError as e:
+        print_error(str(e))
+        raise typer.Exit()
+
+    remote_hash = remote_state.get_hash_remote_state(matcha_state_path)
+
+    if local_hash != remote_hash:
+        remote_state.download(os.getcwd())
+
     if not remote_state.is_state_provisioned():
         print_error("Error - matcha state has not been initialized, nothing to get.")
         raise typer.Exit()

--- a/src/matcha_ml/core/core.py
+++ b/src/matcha_ml/core/core.py
@@ -40,27 +40,29 @@ def get(
             f"Error - matcha.state file does not exist at {os.path.join(os.getcwd(), '.matcha', 'infrastructure')} . Please run 'matcha provision' before trying to get the resource."
         )
 
-    local_hash = matcha_state_service.get_hash_local_state()
-    remote_hash = remote_state.get_hash_remote_state(
-        matcha_state_service.matcha_state_path
-    )
-
-    if local_hash != remote_hash:
-        remote_state.download(os.getcwd())
-
-    if resource_name:
-        get_command_validation(
-            resource_name, matcha_state_service.get_resource_names(), "resource type"
-        )
-
-    if resource_name and property_name:
-        get_command_validation(
-            property_name,
-            matcha_state_service.get_property_names(resource_name),
-            "property",
-        )
-
     with remote_state.use_lock():
+        local_hash = matcha_state_service.get_hash_local_state()
+        remote_hash = remote_state.get_hash_remote_state(
+            matcha_state_service.matcha_state_path
+        )
+
+        if local_hash != remote_hash:
+            remote_state.download(os.getcwd())
+
+        if resource_name:
+            get_command_validation(
+                resource_name,
+                matcha_state_service.get_resource_names(),
+                "resource type",
+            )
+
+        if resource_name and property_name:
+            get_command_validation(
+                property_name,
+                matcha_state_service.get_property_names(resource_name),
+                "property",
+            )
+
         result = matcha_state_service.fetch_resources_from_state_file(
             resource_name, property_name
         )

--- a/src/matcha_ml/core/core.py
+++ b/src/matcha_ml/core/core.py
@@ -28,7 +28,9 @@ def get_local_state_hash(matcha_state_path: str) -> str:
         with open(local_state_path, "rb") as fp:
             local_hash = hashlib.md5(fp.read()).hexdigest()
     else:
-        raise MatchaError(f"Error - matcha state file does not exist at {local_hash}")
+        raise MatchaError(
+            f"Error - matcha state file does not exist at {local_state_path}"
+        )
     return local_hash
 
 

--- a/src/matcha_ml/core/core.py
+++ b/src/matcha_ml/core/core.py
@@ -24,6 +24,7 @@ def get(
         Dict[str, Dict[str, str]]: the information of the provisioned resource.
 
     Raises:
+        MatchaError: Raised when the matcha state has not been initialized
         MatchaError: Raised when the matcha.state file does not exist
         MatchaInputError: Raised when the resource or property name does not exist in the matcha.state file
     """

--- a/src/matcha_ml/core/core.py
+++ b/src/matcha_ml/core/core.py
@@ -1,4 +1,5 @@
 """The core functions for matcha."""
+import hashlib
 import os
 from typing import Dict, Optional
 
@@ -6,6 +7,29 @@ from matcha_ml.cli._validation import get_command_validation
 from matcha_ml.errors import MatchaError
 from matcha_ml.services.global_parameters_service import GlobalParameters
 from matcha_ml.state import MatchaStateService, RemoteStateManager
+
+
+def get_local_state_hash(matcha_state_path: str) -> str:
+    """Get hash of the local matcha state file.
+
+    Args:
+        matcha_state_path (str): Path to the matcha state file.
+
+    Raises:
+        MatchaError: if the matcha state file does not exist
+
+    Returns:
+        str: Hash contents of the blob in hexadecimal string
+    """
+    local_hash = None
+    local_state_path = os.path.join(os.getcwd(), matcha_state_path)
+
+    if os.path.exists(local_state_path):
+        with open(local_state_path, "rb") as fp:
+            local_hash = hashlib.md5(fp.read()).hexdigest()
+    else:
+        raise MatchaError(f"Error - matcha state file does not exist at {local_hash}")
+    return local_hash
 
 
 def get(

--- a/src/matcha_ml/state/matcha_state.py
+++ b/src/matcha_ml/state/matcha_state.py
@@ -1,4 +1,5 @@
 """The matcha state interface."""
+import hashlib
 import json
 import os
 from typing import Dict, List, Optional
@@ -77,3 +78,14 @@ class MatchaStateService:
             List[str]: a list of existing properties for a given resource.
         """
         return list(self._state.get(resource_name, {}).keys())
+
+    def get_hash_local_state(self) -> str:
+        """Get hash of the local matcha state file.
+
+        Returns:
+            str: Hash contents of the blob in hexadecimal string
+        """
+        local_hash = None
+        with open(self.matcha_state_path, "rb") as fp:
+            local_hash = hashlib.md5(fp.read()).hexdigest()
+        return local_hash

--- a/src/matcha_ml/state/remote_state_manager.py
+++ b/src/matcha_ml/state/remote_state_manager.py
@@ -126,7 +126,7 @@ class RemoteStateManager:
         """Check if a bucket for remote state management exists.
 
         Args:
-            container_name: Azure Storage container name
+            container_name (str): Azure Storage container name
 
         Returns:
             bool: True, if the bucket exists
@@ -140,6 +140,19 @@ class RemoteStateManager:
             bool: True, if the resource group exists
         """
         return self.azure_storage.resource_group_exists
+
+    def get_hash_remote_state(self, remote_path: str) -> str:
+        """_summary_.
+
+        Args:
+            remote_path (str) : Path to file on remote storage
+
+        Returns:
+            str: Hash content of file on remote storage in hexadecimal string
+        """
+        return self.azure_storage.get_hash_remote_state(
+            self.configuration.remote_state_bucket.container_name, remote_path
+        )
 
     def is_state_provisioned(self) -> bool:
         """Check if remote state has already been provisioned.

--- a/src/matcha_ml/state/remote_state_manager.py
+++ b/src/matcha_ml/state/remote_state_manager.py
@@ -142,7 +142,7 @@ class RemoteStateManager:
         return self.azure_storage.resource_group_exists
 
     def get_hash_remote_state(self, remote_path: str) -> str:
-        """_summary_.
+        """Get the hash of remote matcha state file.
 
         Args:
             remote_path (str) : Path to file on remote storage

--- a/tests/test_cli/test_get.py
+++ b/tests/test_cli/test_get.py
@@ -179,299 +179,299 @@ def test_cli_get_command_hide_sensitive(
     mock_provisioned_remote_state.use_lock.assert_called_once()
 
 
-# def test_cli_get_command_show_sensitive(
-#     runner: CliRunner,
-#     expected_output_lines: List[str],
-#     mock_provisioned_remote_state: MagicMock,
-# ):
-#     """Test cli for get command when getting all resources with show-sensitive` option specified.
-
-#     Args:
-#         runner (CliRunner): typer CLI runner
-#         expected_output_lines (List[str]): expected output with sensitive value hidden
-#         mock_provisioned_remote_state (MagicMock): mock of an RemoteStateManager instance
-#     """
-#     result = runner.invoke(app, ["get", "--show-sensitive"])
-
-#     # Override fixture to expose sensitive value.
-#     expected_output_lines[2] = "- connection-string: zenml_test_connection_string"
-#     expected_output_lines[3] = "- server-password: zen_server_password"
-
-#     # Exit code 0 means there was no error
-#     assert result.exit_code == 0
-
-#     for line in expected_output_lines:
-#         assert line in result.stdout
-
-#     mock_provisioned_remote_state.use_lock.assert_called_once()
-
-
-# def test_cli_get_command_with_resource(
-#     runner: CliRunner,
-#     expected_output_lines: List[str],
-#     mock_provisioned_remote_state: MagicMock,
-# ):
-#     """Test cli for get command with a specified resource.
-
-#     Args:
-#         runner (CliRunner): typer CLI runner
-#         expected_output_lines (List[str]): expected output with sensitive value hidden
-#         mock_provisioned_remote_state (MagicMock): mock of an RemoteStateManager instance
-#     """
-#     # Invoke get command
-#     result = runner.invoke(app, ["get", "experiment-tracker"])
-
-#     # Exit code 0 means there was no error
-#     assert result.exit_code == 0
-
-#     # expected_output_lines[5:] only includes the experiment-tracker resources.
-#     for line in expected_output_lines[5:]:
-#         assert line in result.stdout
-
-#     # expected_output_lines[:5] checks that pipeline resources are not included in the output.
-#     for line in expected_output_lines[:5]:
-#         assert line not in result.stdout
-
-#     mock_provisioned_remote_state.use_lock.assert_called_once()
-
-
-# def test_cli_get_command_with_invalid_resource_name(
-#     runner: CliRunner, mock_provisioned_remote_state: MagicMock
-# ):
-#     """Test cli for get command with a resource name that does not exist in the state file.
-
-#     Args:
-#         runner (CliRunner): typer CLI runner
-#         mock_provisioned_remote_state (MagicMock): mock of an RemoteStateManager instance
-#     """
-#     # Invoke get command
-#     result = runner.invoke(app, ["get", "does-not-exist"])
-
-#     assert result.exit_code == 0
-#     assert (
-#         "Error - a resource type with the name 'does-not-exist' does not exist."
-#         in result.stdout
-#     )
-
-#     mock_provisioned_remote_state.use_lock.assert_called_once()
-
-
-# def test_cli_get_command_with_resource_and_property(
-#     runner: CliRunner,
-#     expected_output_lines: List[str],
-#     mock_provisioned_remote_state: MagicMock,
-# ):
-#     """Test cli for get command with a specified resource and resource property in default output format.
-
-#     Args:
-#         runner (CliRunner): typer CLI runner
-#         expected_output_lines (List[str]): expected output with sensitive value hidden
-#         mock_provisioned_remote_state (MagicMock): mock of an RemoteStateManager instance
-#     """
-#     # Invoke get command
-#     result = runner.invoke(app, ["get", "experiment-tracker", "tracking-url"])
-
-#     # Exit code 0 means there was no error
-#     assert result.exit_code == 0
-
-#     # expected_output_lines[-1] includes only the tracking-url
-#     for line in expected_output_lines[-1]:
-#         assert line in result.stdout
-
-#     mock_provisioned_remote_state.use_lock.assert_called_once()
-
+def test_cli_get_command_show_sensitive(
+    runner: CliRunner,
+    expected_output_lines: List[str],
+    mock_provisioned_remote_state: MagicMock,
+):
+    """Test cli for get command when getting all resources with show-sensitive` option specified.
+
+    Args:
+        runner (CliRunner): typer CLI runner
+        expected_output_lines (List[str]): expected output with sensitive value hidden
+        mock_provisioned_remote_state (MagicMock): mock of an RemoteStateManager instance
+    """
+    result = runner.invoke(app, ["get", "--show-sensitive"])
+
+    # Override fixture to expose sensitive value.
+    expected_output_lines[2] = "- connection-string: zenml_test_connection_string"
+    expected_output_lines[3] = "- server-password: zen_server_password"
+
+    # Exit code 0 means there was no error
+    assert result.exit_code == 0
+
+    for line in expected_output_lines:
+        assert line in result.stdout
+
+    mock_provisioned_remote_state.use_lock.assert_called_once()
+
+
+def test_cli_get_command_with_resource(
+    runner: CliRunner,
+    expected_output_lines: List[str],
+    mock_provisioned_remote_state: MagicMock,
+):
+    """Test cli for get command with a specified resource.
+
+    Args:
+        runner (CliRunner): typer CLI runner
+        expected_output_lines (List[str]): expected output with sensitive value hidden
+        mock_provisioned_remote_state (MagicMock): mock of an RemoteStateManager instance
+    """
+    # Invoke get command
+    result = runner.invoke(app, ["get", "experiment-tracker"])
+
+    # Exit code 0 means there was no error
+    assert result.exit_code == 0
+
+    # expected_output_lines[5:] only includes the experiment-tracker resources.
+    for line in expected_output_lines[5:]:
+        assert line in result.stdout
+
+    # expected_output_lines[:5] checks that pipeline resources are not included in the output.
+    for line in expected_output_lines[:5]:
+        assert line not in result.stdout
+
+    mock_provisioned_remote_state.use_lock.assert_called_once()
+
+
+def test_cli_get_command_with_invalid_resource_name(
+    runner: CliRunner, mock_provisioned_remote_state: MagicMock
+):
+    """Test cli for get command with a resource name that does not exist in the state file.
+
+    Args:
+        runner (CliRunner): typer CLI runner
+        mock_provisioned_remote_state (MagicMock): mock of an RemoteStateManager instance
+    """
+    # Invoke get command
+    result = runner.invoke(app, ["get", "does-not-exist"])
+
+    assert result.exit_code == 0
+    assert (
+        "Error - a resource type with the name 'does-not-exist' does not exist."
+        in result.stdout
+    )
+
+    mock_provisioned_remote_state.use_lock.assert_called_once()
+
+
+def test_cli_get_command_with_resource_and_property(
+    runner: CliRunner,
+    expected_output_lines: List[str],
+    mock_provisioned_remote_state: MagicMock,
+):
+    """Test cli for get command with a specified resource and resource property in default output format.
+
+    Args:
+        runner (CliRunner): typer CLI runner
+        expected_output_lines (List[str]): expected output with sensitive value hidden
+        mock_provisioned_remote_state (MagicMock): mock of an RemoteStateManager instance
+    """
+    # Invoke get command
+    result = runner.invoke(app, ["get", "experiment-tracker", "tracking-url"])
+
+    # Exit code 0 means there was no error
+    assert result.exit_code == 0
+
+    # expected_output_lines[-1] includes only the tracking-url
+    for line in expected_output_lines[-1]:
+        assert line in result.stdout
+
+    mock_provisioned_remote_state.use_lock.assert_called_once()
+
 
-# def test_cli_get_command_with_resource_and_property_json(
-#     runner: CliRunner,
-#     expected_outputs_json: Dict[str, Dict[str, str]],
-#     mock_provisioned_remote_state: MagicMock,
-# ):
-#     """Test cli for get command with a specified resource and resource property in JSON output format.
-
-#     Args:
-#         runner (CliRunner): typer CLI runner
-#         expected_outputs_json (dict): expected output with sensitive value hidden in JSON output format
-#         mock_provisioned_remote_state (MagicMock): mock of an RemoteStateManager instance
-#     """
-#     expected_output = json.dumps(
-#         expected_outputs_json["experiment-tracker"]["tracking-url"], indent=2
-#     )
-
-#     # Invoke get command
-#     result = runner.invoke(
-#         app, ["get", "experiment-tracker", "tracking-url", "--output", "json"]
-#     )
-
-#     # Exit code 0 means there was no error
-#     assert result.exit_code == 0
-#     # Assert JSON is present and correct in cli output
-#     assert expected_output in result.stdout
-
-#     mock_provisioned_remote_state.use_lock.assert_called_once()
-
-
-# def test_cli_get_command_json_no_show_sensitive(
-#     runner: CliRunner,
-#     expected_outputs_json: Dict[str, Dict[str, str]],
-#     mock_provisioned_remote_state: MagicMock,
-# ):
-#     """Test cli get command default in JSON output with no `show-sensitive` option specified.
-
-#     Args:
-#         runner (CliRunner): typer CLI runner
-#         expected_outputs_json (dict): expected output with sensitive value hidden in JSON output format
-#         mock_provisioned_remote_state (MagicMock): mock of an RemoteStateManager instance
-#     """
-#     expected_output = json.dumps(expected_outputs_json, indent=2)
-
-#     # Invoke get command
-#     result = runner.invoke(app, ["get", "--output", "json"])
-
-#     # Exit code 0 means there was no error
-#     assert result.exit_code == 0
-#     # Assert JSON is present and correct in cli output
-#     assert expected_output in result.stdout
-
-#     mock_provisioned_remote_state.use_lock.assert_called_once()
-
-
-# def test_cli_get_command_yaml_no_show_sensitive(
-#     runner: CliRunner,
-#     expected_output_lines_yaml: List[str],
-#     mock_provisioned_remote_state: MagicMock,
-# ):
-#     """Test cli get command default in YAML output with `show-sensitive` option specified..
-
-#     Args:
-#         runner (CliRunner): typer CLI runner
-#         expected_output_lines_yaml (List[str]): expected output with sensitive value hidden in yaml output format
-#         mock_provisioned_remote_state (MagicMock): mock of an RemoteStateManager instance
-#     """
-#     # Invoke get command
-#     result = runner.invoke(app, ["get", "--output", "yaml"])
-
-#     # Exit code 0 means there was no error
-#     assert result.exit_code == 0
-#     # Assert YAML is present and correct in cli output
-#     for line in expected_output_lines_yaml:
-#         assert line in result.stdout
-
-#     mock_provisioned_remote_state.use_lock.assert_called_once()
-
-
-# def test_cli_get_command_json_show_sensitive(
-#     runner: CliRunner,
-#     expected_outputs_json: Dict[str, Dict[str, str]],
-#     mock_provisioned_remote_state: MagicMock,
-# ):
-#     """Test cli get command default in JSON output with `show-sensitive` option specified..
-
-#     Args:
-#         runner (CliRunner): typer CLI runner
-#         expected_outputs_json (dict): expected output with sensitive value hidden in JSON output format
-#         mock_provisioned_remote_state (MagicMock): mock of an RemoteStateManager instance
-#     """
-#     expected_outputs_json["pipeline"][
-#         "connection-string"
-#     ] = "zenml_test_connection_string"
-#     expected_outputs_json["pipeline"]["server-password"] = "zen_server_password"
-
-#     expected_output = json.dumps(expected_outputs_json, indent=2)
-
-#     # Invoke get command
-#     result = runner.invoke(app, ["get", "--output", "json", "--show-sensitive"])
-
-#     # Exit code 0 means there was no error
-#     assert result.exit_code == 0
-#     # Assert JSON is present and correct in cli output
-#     assert expected_output in result.stdout
-
-#     mock_provisioned_remote_state.use_lock.assert_called_once()
-
-
-# def test_cli_get_command_yaml_show_sensitive(
-#     runner: CliRunner,
-#     expected_output_lines_yaml: List[str],
-#     mock_provisioned_remote_state: MagicMock,
-# ):
-#     """Test cli get command default in YAML output with `show-sensitive` option specified..
-
-#     Args:
-#         runner (CliRunner): typer CLI runner
-#         expected_output_lines_yaml (List[str]): expected output with sensitive value hidden in yaml output format
-#         mock_provisioned_remote_state (MagicMock): mock of an RemoteStateManager instance
-#     """
-#     # Override fixture to expose sensitive value.
-#     expected_output_lines_yaml[4] = "connection-string: zenml_test_connection_string"
-#     expected_output_lines_yaml[6] = "server-password: zen_server_password"
-
-#     # Invoke get command
-#     result = runner.invoke(app, ["get", "--output", "yaml", "--show-sensitive"])
-
-#     # Exit code 0 means there was no error
-#     assert result.exit_code == 0
-#     # Assert YAML is present and correct in cli output
-#     for line in expected_output_lines_yaml:
-#         assert line in result.stdout
-
-#     mock_provisioned_remote_state.use_lock.assert_called_once()
-
-
-# def test_cli_get_command_no_show_sensitive_with_sensitive_resource(
-#     runner: CliRunner,
-#     expected_output_lines: List[str],
-#     mock_provisioned_remote_state: MagicMock,
-# ):
-#     """Test cli get command for when getting resource with sensitive value with no `show-sensitive` option specified.
-
-#     Args:
-#         runner (CliRunner): typer CLI runner
-#         expected_output_lines (List[str]): expected output with sensitive value hidden
-#         mock_provisioned_remote_state (MagicMock): mock of an RemoteStateManager instance
-#     """
-#     result = runner.invoke(app, ["get", "pipeline"])
-
-#     # Exit code 0 means there was no error
-#     assert result.exit_code == 0
-
-#     # expected_output_lines[:5] does not include experiment tracker.
-#     for line in expected_output_lines[:5]:
-#         assert line in result.stdout
-
-#     # expected_output_lines[5:] checks experiment tracker not in output.
-#     for line in expected_output_lines[5:]:
-#         assert line not in result.stdout
-
-#     mock_provisioned_remote_state.use_lock.assert_called_once()
-
-
-# def test_cli_get_command_show_sensitive_with_resource(
-#     runner: CliRunner,
-#     expected_output_lines: List[str],
-#     mock_provisioned_remote_state: MagicMock,
-# ):
-#     """Test cli get command for when getting resource with sensitive value with `show-sensitive` option specified.
-
-#     Args:
-#         runner (CliRunner): typer CLI runner
-#         expected_output_lines (List[str]): expected output with sensitive value hidden
-#         mock_provisioned_remote_state (MagicMock): mock of an RemoteStateManager instance
-#     """
-#     result = runner.invoke(app, ["get", "pipeline", "--show-sensitive"])
-
-#     # Override fixture to expose sensitive value.
-#     expected_output_lines[2] = "- connection-string: zenml_test_connection_string"
-#     expected_output_lines[3] = "- server-password: zen_server_password"
-
-#     # Exit code 0 means there was no error
-#     assert result.exit_code == 0
-
-#     # expected_output_lines[:5] does not include experiment tracker.
-#     for line in expected_output_lines[:5]:
-#         assert line in result.stdout
-
-#     # expected_output_lines[5:] checks experiment tracker not in output.
-#     for line in expected_output_lines[5:]:
-#         assert line not in result.stdout
-
-#     mock_provisioned_remote_state.use_lock.assert_called_once()
+def test_cli_get_command_with_resource_and_property_json(
+    runner: CliRunner,
+    expected_outputs_json: Dict[str, Dict[str, str]],
+    mock_provisioned_remote_state: MagicMock,
+):
+    """Test cli for get command with a specified resource and resource property in JSON output format.
+
+    Args:
+        runner (CliRunner): typer CLI runner
+        expected_outputs_json (dict): expected output with sensitive value hidden in JSON output format
+        mock_provisioned_remote_state (MagicMock): mock of an RemoteStateManager instance
+    """
+    expected_output = json.dumps(
+        expected_outputs_json["experiment-tracker"]["tracking-url"], indent=2
+    )
+
+    # Invoke get command
+    result = runner.invoke(
+        app, ["get", "experiment-tracker", "tracking-url", "--output", "json"]
+    )
+
+    # Exit code 0 means there was no error
+    assert result.exit_code == 0
+    # Assert JSON is present and correct in cli output
+    assert expected_output in result.stdout
+
+    mock_provisioned_remote_state.use_lock.assert_called_once()
+
+
+def test_cli_get_command_json_no_show_sensitive(
+    runner: CliRunner,
+    expected_outputs_json: Dict[str, Dict[str, str]],
+    mock_provisioned_remote_state: MagicMock,
+):
+    """Test cli get command default in JSON output with no `show-sensitive` option specified.
+
+    Args:
+        runner (CliRunner): typer CLI runner
+        expected_outputs_json (dict): expected output with sensitive value hidden in JSON output format
+        mock_provisioned_remote_state (MagicMock): mock of an RemoteStateManager instance
+    """
+    expected_output = json.dumps(expected_outputs_json, indent=2)
+
+    # Invoke get command
+    result = runner.invoke(app, ["get", "--output", "json"])
+
+    # Exit code 0 means there was no error
+    assert result.exit_code == 0
+    # Assert JSON is present and correct in cli output
+    assert expected_output in result.stdout
+
+    mock_provisioned_remote_state.use_lock.assert_called_once()
+
+
+def test_cli_get_command_yaml_no_show_sensitive(
+    runner: CliRunner,
+    expected_output_lines_yaml: List[str],
+    mock_provisioned_remote_state: MagicMock,
+):
+    """Test cli get command default in YAML output with `show-sensitive` option specified..
+
+    Args:
+        runner (CliRunner): typer CLI runner
+        expected_output_lines_yaml (List[str]): expected output with sensitive value hidden in yaml output format
+        mock_provisioned_remote_state (MagicMock): mock of an RemoteStateManager instance
+    """
+    # Invoke get command
+    result = runner.invoke(app, ["get", "--output", "yaml"])
+
+    # Exit code 0 means there was no error
+    assert result.exit_code == 0
+    # Assert YAML is present and correct in cli output
+    for line in expected_output_lines_yaml:
+        assert line in result.stdout
+
+    mock_provisioned_remote_state.use_lock.assert_called_once()
+
+
+def test_cli_get_command_json_show_sensitive(
+    runner: CliRunner,
+    expected_outputs_json: Dict[str, Dict[str, str]],
+    mock_provisioned_remote_state: MagicMock,
+):
+    """Test cli get command default in JSON output with `show-sensitive` option specified..
+
+    Args:
+        runner (CliRunner): typer CLI runner
+        expected_outputs_json (dict): expected output with sensitive value hidden in JSON output format
+        mock_provisioned_remote_state (MagicMock): mock of an RemoteStateManager instance
+    """
+    expected_outputs_json["pipeline"][
+        "connection-string"
+    ] = "zenml_test_connection_string"
+    expected_outputs_json["pipeline"]["server-password"] = "zen_server_password"
+
+    expected_output = json.dumps(expected_outputs_json, indent=2)
+
+    # Invoke get command
+    result = runner.invoke(app, ["get", "--output", "json", "--show-sensitive"])
+
+    # Exit code 0 means there was no error
+    assert result.exit_code == 0
+    # Assert JSON is present and correct in cli output
+    assert expected_output in result.stdout
+
+    mock_provisioned_remote_state.use_lock.assert_called_once()
+
+
+def test_cli_get_command_yaml_show_sensitive(
+    runner: CliRunner,
+    expected_output_lines_yaml: List[str],
+    mock_provisioned_remote_state: MagicMock,
+):
+    """Test cli get command default in YAML output with `show-sensitive` option specified..
+
+    Args:
+        runner (CliRunner): typer CLI runner
+        expected_output_lines_yaml (List[str]): expected output with sensitive value hidden in yaml output format
+        mock_provisioned_remote_state (MagicMock): mock of an RemoteStateManager instance
+    """
+    # Override fixture to expose sensitive value.
+    expected_output_lines_yaml[4] = "connection-string: zenml_test_connection_string"
+    expected_output_lines_yaml[6] = "server-password: zen_server_password"
+
+    # Invoke get command
+    result = runner.invoke(app, ["get", "--output", "yaml", "--show-sensitive"])
+
+    # Exit code 0 means there was no error
+    assert result.exit_code == 0
+    # Assert YAML is present and correct in cli output
+    for line in expected_output_lines_yaml:
+        assert line in result.stdout
+
+    mock_provisioned_remote_state.use_lock.assert_called_once()
+
+
+def test_cli_get_command_no_show_sensitive_with_sensitive_resource(
+    runner: CliRunner,
+    expected_output_lines: List[str],
+    mock_provisioned_remote_state: MagicMock,
+):
+    """Test cli get command for when getting resource with sensitive value with no `show-sensitive` option specified.
+
+    Args:
+        runner (CliRunner): typer CLI runner
+        expected_output_lines (List[str]): expected output with sensitive value hidden
+        mock_provisioned_remote_state (MagicMock): mock of an RemoteStateManager instance
+    """
+    result = runner.invoke(app, ["get", "pipeline"])
+
+    # Exit code 0 means there was no error
+    assert result.exit_code == 0
+
+    # expected_output_lines[:5] does not include experiment tracker.
+    for line in expected_output_lines[:5]:
+        assert line in result.stdout
+
+    # expected_output_lines[5:] checks experiment tracker not in output.
+    for line in expected_output_lines[5:]:
+        assert line not in result.stdout
+
+    mock_provisioned_remote_state.use_lock.assert_called_once()
+
+
+def test_cli_get_command_show_sensitive_with_resource(
+    runner: CliRunner,
+    expected_output_lines: List[str],
+    mock_provisioned_remote_state: MagicMock,
+):
+    """Test cli get command for when getting resource with sensitive value with `show-sensitive` option specified.
+
+    Args:
+        runner (CliRunner): typer CLI runner
+        expected_output_lines (List[str]): expected output with sensitive value hidden
+        mock_provisioned_remote_state (MagicMock): mock of an RemoteStateManager instance
+    """
+    result = runner.invoke(app, ["get", "pipeline", "--show-sensitive"])
+
+    # Override fixture to expose sensitive value.
+    expected_output_lines[2] = "- connection-string: zenml_test_connection_string"
+    expected_output_lines[3] = "- server-password: zen_server_password"
+
+    # Exit code 0 means there was no error
+    assert result.exit_code == 0
+
+    # expected_output_lines[:5] does not include experiment tracker.
+    for line in expected_output_lines[:5]:
+        assert line in result.stdout
+
+    # expected_output_lines[5:] checks experiment tracker not in output.
+    for line in expected_output_lines[5:]:
+        assert line not in result.stdout
+
+    mock_provisioned_remote_state.use_lock.assert_called_once()

--- a/tests/test_cli/test_get.py
+++ b/tests/test_cli/test_get.py
@@ -17,7 +17,7 @@ def mock_provisioned_remote_state() -> Iterable[MagicMock]:
     Returns:
         MagicMock: mock of an RemoteStateManager instance
     """
-    with patch("matcha_ml.cli.cli.RemoteStateManager") as mock_state_manager_class:
+    with patch("matcha_ml.core.core.RemoteStateManager") as mock_state_manager_class:
         mock_state_manager = mock_state_manager_class.return_value
         mock_state_manager.is_state_provisioned.return_value = True
         mock_state_manager.get_hash_remote_state.return_value = (
@@ -151,7 +151,7 @@ def test_cli_get_command_with_no_state_file(
     result = runner.invoke(app, ["get"])
 
     assert result.exit_code == 0
-    assert "Error - matcha state file does not exist at" in str(result.stdout)
+    assert "Error - matcha.state file does not exist at" in str(result.stdout)
 
     mock_provisioned_remote_state.use_lock.assert_not_called()
 

--- a/tests/test_cli/test_get.py
+++ b/tests/test_cli/test_get.py
@@ -148,327 +148,327 @@ def test_cli_get_command_with_no_state_file(
     result = runner.invoke(app, ["get"])
 
     assert result.exit_code == 0
-    assert "Error: matcha.state file does not exist at" in str(result.stdout)
+    assert "Error - matcha.state file does not exist at" in str(result.stdout)
 
     mock_provisioned_remote_state.use_lock.assert_called_once()
 
 
-def test_cli_get_command_hide_sensitive(
-    runner: CliRunner,
-    expected_output_lines: List[str],
-    mock_provisioned_remote_state: MagicMock,
-):
-    """Test cli get command when getting all resources with no `show-sensitive` option specified.
-
-    Args:
-        runner (CliRunner): typer CLI runner
-        expected_output_lines (List[str]): expected output with sensitive value hidden
-        mock_provisioned_remote_state (MagicMock): mock of an RemoteStateManager instance
-    """
-    result = runner.invoke(app, ["get"])
-
-    # Exit code 0 means there was no error
-    assert result.exit_code == 0
-
-    for line in expected_output_lines:
-        assert line in result.stdout
-
-    mock_provisioned_remote_state.use_lock.assert_called_once()
-
-
-def test_cli_get_command_show_sensitive(
-    runner: CliRunner,
-    expected_output_lines: List[str],
-    mock_provisioned_remote_state: MagicMock,
-):
-    """Test cli for get command when getting all resources with show-sensitive` option specified.
-
-    Args:
-        runner (CliRunner): typer CLI runner
-        expected_output_lines (List[str]): expected output with sensitive value hidden
-        mock_provisioned_remote_state (MagicMock): mock of an RemoteStateManager instance
-    """
-    result = runner.invoke(app, ["get", "--show-sensitive"])
-
-    # Override fixture to expose sensitive value.
-    expected_output_lines[2] = "- connection-string: zenml_test_connection_string"
-    expected_output_lines[3] = "- server-password: zen_server_password"
-
-    # Exit code 0 means there was no error
-    assert result.exit_code == 0
-
-    for line in expected_output_lines:
-        assert line in result.stdout
-
-    mock_provisioned_remote_state.use_lock.assert_called_once()
-
-
-def test_cli_get_command_with_resource(
-    runner: CliRunner,
-    expected_output_lines: List[str],
-    mock_provisioned_remote_state: MagicMock,
-):
-    """Test cli for get command with a specified resource.
-
-    Args:
-        runner (CliRunner): typer CLI runner
-        expected_output_lines (List[str]): expected output with sensitive value hidden
-        mock_provisioned_remote_state (MagicMock): mock of an RemoteStateManager instance
-    """
-    # Invoke get command
-    result = runner.invoke(app, ["get", "experiment-tracker"])
-
-    # Exit code 0 means there was no error
-    assert result.exit_code == 0
-
-    # expected_output_lines[5:] only includes the experiment-tracker resources.
-    for line in expected_output_lines[5:]:
-        assert line in result.stdout
-
-    # expected_output_lines[:5] checks that pipeline resources are not included in the output.
-    for line in expected_output_lines[:5]:
-        assert line not in result.stdout
-
-    mock_provisioned_remote_state.use_lock.assert_called_once()
-
-
-def test_cli_get_command_with_invalid_resource_name(
-    runner: CliRunner, mock_provisioned_remote_state: MagicMock
-):
-    """Test cli for get command with a resource name that does not exist in the state file.
-
-    Args:
-        runner (CliRunner): typer CLI runner
-        mock_provisioned_remote_state (MagicMock): mock of an RemoteStateManager instance
-    """
-    # Invoke get command
-    result = runner.invoke(app, ["get", "does-not-exist"])
-
-    assert result.exit_code == 0
-    assert (
-        "Error - a resource type with the name 'does-not-exist' does not exist."
-        in result.stdout
-    )
-
-    mock_provisioned_remote_state.use_lock.assert_called_once()
-
-
-def test_cli_get_command_with_resource_and_property(
-    runner: CliRunner,
-    expected_output_lines: List[str],
-    mock_provisioned_remote_state: MagicMock,
-):
-    """Test cli for get command with a specified resource and resource property in default output format.
-
-    Args:
-        runner (CliRunner): typer CLI runner
-        expected_output_lines (List[str]): expected output with sensitive value hidden
-        mock_provisioned_remote_state (MagicMock): mock of an RemoteStateManager instance
-    """
-    # Invoke get command
-    result = runner.invoke(app, ["get", "experiment-tracker", "tracking-url"])
-
-    # Exit code 0 means there was no error
-    assert result.exit_code == 0
-
-    # expected_output_lines[-1] includes only the tracking-url
-    for line in expected_output_lines[-1]:
-        assert line in result.stdout
-
-    mock_provisioned_remote_state.use_lock.assert_called_once()
-
-
-def test_cli_get_command_with_resource_and_property_json(
-    runner: CliRunner,
-    expected_outputs_json: Dict[str, Dict[str, str]],
-    mock_provisioned_remote_state: MagicMock,
-):
-    """Test cli for get command with a specified resource and resource property in JSON output format.
-
-    Args:
-        runner (CliRunner): typer CLI runner
-        expected_outputs_json (dict): expected output with sensitive value hidden in JSON output format
-        mock_provisioned_remote_state (MagicMock): mock of an RemoteStateManager instance
-    """
-    expected_output = json.dumps(
-        expected_outputs_json["experiment-tracker"]["tracking-url"], indent=2
-    )
-
-    # Invoke get command
-    result = runner.invoke(
-        app, ["get", "experiment-tracker", "tracking-url", "--output", "json"]
-    )
-
-    # Exit code 0 means there was no error
-    assert result.exit_code == 0
-    # Assert JSON is present and correct in cli output
-    assert expected_output in result.stdout
-
-    mock_provisioned_remote_state.use_lock.assert_called_once()
-
-
-def test_cli_get_command_json_no_show_sensitive(
-    runner: CliRunner,
-    expected_outputs_json: Dict[str, Dict[str, str]],
-    mock_provisioned_remote_state: MagicMock,
-):
-    """Test cli get command default in JSON output with no `show-sensitive` option specified.
-
-    Args:
-        runner (CliRunner): typer CLI runner
-        expected_outputs_json (dict): expected output with sensitive value hidden in JSON output format
-        mock_provisioned_remote_state (MagicMock): mock of an RemoteStateManager instance
-    """
-    expected_output = json.dumps(expected_outputs_json, indent=2)
-
-    # Invoke get command
-    result = runner.invoke(app, ["get", "--output", "json"])
-
-    # Exit code 0 means there was no error
-    assert result.exit_code == 0
-    # Assert JSON is present and correct in cli output
-    assert expected_output in result.stdout
-
-    mock_provisioned_remote_state.use_lock.assert_called_once()
-
-
-def test_cli_get_command_yaml_no_show_sensitive(
-    runner: CliRunner,
-    expected_output_lines_yaml: List[str],
-    mock_provisioned_remote_state: MagicMock,
-):
-    """Test cli get command default in YAML output with `show-sensitive` option specified..
-
-    Args:
-        runner (CliRunner): typer CLI runner
-        expected_output_lines_yaml (List[str]): expected output with sensitive value hidden in yaml output format
-        mock_provisioned_remote_state (MagicMock): mock of an RemoteStateManager instance
-    """
-    # Invoke get command
-    result = runner.invoke(app, ["get", "--output", "yaml"])
-
-    # Exit code 0 means there was no error
-    assert result.exit_code == 0
-    # Assert YAML is present and correct in cli output
-    for line in expected_output_lines_yaml:
-        assert line in result.stdout
-
-    mock_provisioned_remote_state.use_lock.assert_called_once()
-
-
-def test_cli_get_command_json_show_sensitive(
-    runner: CliRunner,
-    expected_outputs_json: Dict[str, Dict[str, str]],
-    mock_provisioned_remote_state: MagicMock,
-):
-    """Test cli get command default in JSON output with `show-sensitive` option specified..
-
-    Args:
-        runner (CliRunner): typer CLI runner
-        expected_outputs_json (dict): expected output with sensitive value hidden in JSON output format
-        mock_provisioned_remote_state (MagicMock): mock of an RemoteStateManager instance
-    """
-    expected_outputs_json["pipeline"][
-        "connection-string"
-    ] = "zenml_test_connection_string"
-    expected_outputs_json["pipeline"]["server-password"] = "zen_server_password"
-
-    expected_output = json.dumps(expected_outputs_json, indent=2)
-
-    # Invoke get command
-    result = runner.invoke(app, ["get", "--output", "json", "--show-sensitive"])
-
-    # Exit code 0 means there was no error
-    assert result.exit_code == 0
-    # Assert JSON is present and correct in cli output
-    assert expected_output in result.stdout
-
-    mock_provisioned_remote_state.use_lock.assert_called_once()
-
-
-def test_cli_get_command_yaml_show_sensitive(
-    runner: CliRunner,
-    expected_output_lines_yaml: List[str],
-    mock_provisioned_remote_state: MagicMock,
-):
-    """Test cli get command default in YAML output with `show-sensitive` option specified..
-
-    Args:
-        runner (CliRunner): typer CLI runner
-        expected_output_lines_yaml (List[str]): expected output with sensitive value hidden in yaml output format
-        mock_provisioned_remote_state (MagicMock): mock of an RemoteStateManager instance
-    """
-    # Override fixture to expose sensitive value.
-    expected_output_lines_yaml[4] = "connection-string: zenml_test_connection_string"
-    expected_output_lines_yaml[6] = "server-password: zen_server_password"
-
-    # Invoke get command
-    result = runner.invoke(app, ["get", "--output", "yaml", "--show-sensitive"])
-
-    # Exit code 0 means there was no error
-    assert result.exit_code == 0
-    # Assert YAML is present and correct in cli output
-    for line in expected_output_lines_yaml:
-        assert line in result.stdout
-
-    mock_provisioned_remote_state.use_lock.assert_called_once()
-
-
-def test_cli_get_command_no_show_sensitive_with_sensitive_resource(
-    runner: CliRunner,
-    expected_output_lines: List[str],
-    mock_provisioned_remote_state: MagicMock,
-):
-    """Test cli get command for when getting resource with sensitive value with no `show-sensitive` option specified.
-
-    Args:
-        runner (CliRunner): typer CLI runner
-        expected_output_lines (List[str]): expected output with sensitive value hidden
-        mock_provisioned_remote_state (MagicMock): mock of an RemoteStateManager instance
-    """
-    result = runner.invoke(app, ["get", "pipeline"])
-
-    # Exit code 0 means there was no error
-    assert result.exit_code == 0
-
-    # expected_output_lines[:5] does not include experiment tracker.
-    for line in expected_output_lines[:5]:
-        assert line in result.stdout
-
-    # expected_output_lines[5:] checks experiment tracker not in output.
-    for line in expected_output_lines[5:]:
-        assert line not in result.stdout
-
-    mock_provisioned_remote_state.use_lock.assert_called_once()
-
-
-def test_cli_get_command_show_sensitive_with_resource(
-    runner: CliRunner,
-    expected_output_lines: List[str],
-    mock_provisioned_remote_state: MagicMock,
-):
-    """Test cli get command for when getting resource with sensitive value with `show-sensitive` option specified.
-
-    Args:
-        runner (CliRunner): typer CLI runner
-        expected_output_lines (List[str]): expected output with sensitive value hidden
-        mock_provisioned_remote_state (MagicMock): mock of an RemoteStateManager instance
-    """
-    result = runner.invoke(app, ["get", "pipeline", "--show-sensitive"])
-
-    # Override fixture to expose sensitive value.
-    expected_output_lines[2] = "- connection-string: zenml_test_connection_string"
-    expected_output_lines[3] = "- server-password: zen_server_password"
-
-    # Exit code 0 means there was no error
-    assert result.exit_code == 0
-
-    # expected_output_lines[:5] does not include experiment tracker.
-    for line in expected_output_lines[:5]:
-        assert line in result.stdout
-
-    # expected_output_lines[5:] checks experiment tracker not in output.
-    for line in expected_output_lines[5:]:
-        assert line not in result.stdout
-
-    mock_provisioned_remote_state.use_lock.assert_called_once()
+# def test_cli_get_command_hide_sensitive(
+#     runner: CliRunner,
+#     expected_output_lines: List[str],
+#     mock_provisioned_remote_state: MagicMock,
+# ):
+#     """Test cli get command when getting all resources with no `show-sensitive` option specified.
+
+#     Args:
+#         runner (CliRunner): typer CLI runner
+#         expected_output_lines (List[str]): expected output with sensitive value hidden
+#         mock_provisioned_remote_state (MagicMock): mock of an RemoteStateManager instance
+#     """
+#     result = runner.invoke(app, ["get"])
+
+#     # Exit code 0 means there was no error
+#     assert result.exit_code == 0
+
+#     for line in expected_output_lines:
+#         assert line in result.stdout
+
+#     mock_provisioned_remote_state.use_lock.assert_called_once()
+
+
+# def test_cli_get_command_show_sensitive(
+#     runner: CliRunner,
+#     expected_output_lines: List[str],
+#     mock_provisioned_remote_state: MagicMock,
+# ):
+#     """Test cli for get command when getting all resources with show-sensitive` option specified.
+
+#     Args:
+#         runner (CliRunner): typer CLI runner
+#         expected_output_lines (List[str]): expected output with sensitive value hidden
+#         mock_provisioned_remote_state (MagicMock): mock of an RemoteStateManager instance
+#     """
+#     result = runner.invoke(app, ["get", "--show-sensitive"])
+
+#     # Override fixture to expose sensitive value.
+#     expected_output_lines[2] = "- connection-string: zenml_test_connection_string"
+#     expected_output_lines[3] = "- server-password: zen_server_password"
+
+#     # Exit code 0 means there was no error
+#     assert result.exit_code == 0
+
+#     for line in expected_output_lines:
+#         assert line in result.stdout
+
+#     mock_provisioned_remote_state.use_lock.assert_called_once()
+
+
+# def test_cli_get_command_with_resource(
+#     runner: CliRunner,
+#     expected_output_lines: List[str],
+#     mock_provisioned_remote_state: MagicMock,
+# ):
+#     """Test cli for get command with a specified resource.
+
+#     Args:
+#         runner (CliRunner): typer CLI runner
+#         expected_output_lines (List[str]): expected output with sensitive value hidden
+#         mock_provisioned_remote_state (MagicMock): mock of an RemoteStateManager instance
+#     """
+#     # Invoke get command
+#     result = runner.invoke(app, ["get", "experiment-tracker"])
+
+#     # Exit code 0 means there was no error
+#     assert result.exit_code == 0
+
+#     # expected_output_lines[5:] only includes the experiment-tracker resources.
+#     for line in expected_output_lines[5:]:
+#         assert line in result.stdout
+
+#     # expected_output_lines[:5] checks that pipeline resources are not included in the output.
+#     for line in expected_output_lines[:5]:
+#         assert line not in result.stdout
+
+#     mock_provisioned_remote_state.use_lock.assert_called_once()
+
+
+# def test_cli_get_command_with_invalid_resource_name(
+#     runner: CliRunner, mock_provisioned_remote_state: MagicMock
+# ):
+#     """Test cli for get command with a resource name that does not exist in the state file.
+
+#     Args:
+#         runner (CliRunner): typer CLI runner
+#         mock_provisioned_remote_state (MagicMock): mock of an RemoteStateManager instance
+#     """
+#     # Invoke get command
+#     result = runner.invoke(app, ["get", "does-not-exist"])
+
+#     assert result.exit_code == 0
+#     assert (
+#         "Error - a resource type with the name 'does-not-exist' does not exist."
+#         in result.stdout
+#     )
+
+#     mock_provisioned_remote_state.use_lock.assert_called_once()
+
+
+# def test_cli_get_command_with_resource_and_property(
+#     runner: CliRunner,
+#     expected_output_lines: List[str],
+#     mock_provisioned_remote_state: MagicMock,
+# ):
+#     """Test cli for get command with a specified resource and resource property in default output format.
+
+#     Args:
+#         runner (CliRunner): typer CLI runner
+#         expected_output_lines (List[str]): expected output with sensitive value hidden
+#         mock_provisioned_remote_state (MagicMock): mock of an RemoteStateManager instance
+#     """
+#     # Invoke get command
+#     result = runner.invoke(app, ["get", "experiment-tracker", "tracking-url"])
+
+#     # Exit code 0 means there was no error
+#     assert result.exit_code == 0
+
+#     # expected_output_lines[-1] includes only the tracking-url
+#     for line in expected_output_lines[-1]:
+#         assert line in result.stdout
+
+#     mock_provisioned_remote_state.use_lock.assert_called_once()
+
+
+# def test_cli_get_command_with_resource_and_property_json(
+#     runner: CliRunner,
+#     expected_outputs_json: Dict[str, Dict[str, str]],
+#     mock_provisioned_remote_state: MagicMock,
+# ):
+#     """Test cli for get command with a specified resource and resource property in JSON output format.
+
+#     Args:
+#         runner (CliRunner): typer CLI runner
+#         expected_outputs_json (dict): expected output with sensitive value hidden in JSON output format
+#         mock_provisioned_remote_state (MagicMock): mock of an RemoteStateManager instance
+#     """
+#     expected_output = json.dumps(
+#         expected_outputs_json["experiment-tracker"]["tracking-url"], indent=2
+#     )
+
+#     # Invoke get command
+#     result = runner.invoke(
+#         app, ["get", "experiment-tracker", "tracking-url", "--output", "json"]
+#     )
+
+#     # Exit code 0 means there was no error
+#     assert result.exit_code == 0
+#     # Assert JSON is present and correct in cli output
+#     assert expected_output in result.stdout
+
+#     mock_provisioned_remote_state.use_lock.assert_called_once()
+
+
+# def test_cli_get_command_json_no_show_sensitive(
+#     runner: CliRunner,
+#     expected_outputs_json: Dict[str, Dict[str, str]],
+#     mock_provisioned_remote_state: MagicMock,
+# ):
+#     """Test cli get command default in JSON output with no `show-sensitive` option specified.
+
+#     Args:
+#         runner (CliRunner): typer CLI runner
+#         expected_outputs_json (dict): expected output with sensitive value hidden in JSON output format
+#         mock_provisioned_remote_state (MagicMock): mock of an RemoteStateManager instance
+#     """
+#     expected_output = json.dumps(expected_outputs_json, indent=2)
+
+#     # Invoke get command
+#     result = runner.invoke(app, ["get", "--output", "json"])
+
+#     # Exit code 0 means there was no error
+#     assert result.exit_code == 0
+#     # Assert JSON is present and correct in cli output
+#     assert expected_output in result.stdout
+
+#     mock_provisioned_remote_state.use_lock.assert_called_once()
+
+
+# def test_cli_get_command_yaml_no_show_sensitive(
+#     runner: CliRunner,
+#     expected_output_lines_yaml: List[str],
+#     mock_provisioned_remote_state: MagicMock,
+# ):
+#     """Test cli get command default in YAML output with `show-sensitive` option specified..
+
+#     Args:
+#         runner (CliRunner): typer CLI runner
+#         expected_output_lines_yaml (List[str]): expected output with sensitive value hidden in yaml output format
+#         mock_provisioned_remote_state (MagicMock): mock of an RemoteStateManager instance
+#     """
+#     # Invoke get command
+#     result = runner.invoke(app, ["get", "--output", "yaml"])
+
+#     # Exit code 0 means there was no error
+#     assert result.exit_code == 0
+#     # Assert YAML is present and correct in cli output
+#     for line in expected_output_lines_yaml:
+#         assert line in result.stdout
+
+#     mock_provisioned_remote_state.use_lock.assert_called_once()
+
+
+# def test_cli_get_command_json_show_sensitive(
+#     runner: CliRunner,
+#     expected_outputs_json: Dict[str, Dict[str, str]],
+#     mock_provisioned_remote_state: MagicMock,
+# ):
+#     """Test cli get command default in JSON output with `show-sensitive` option specified..
+
+#     Args:
+#         runner (CliRunner): typer CLI runner
+#         expected_outputs_json (dict): expected output with sensitive value hidden in JSON output format
+#         mock_provisioned_remote_state (MagicMock): mock of an RemoteStateManager instance
+#     """
+#     expected_outputs_json["pipeline"][
+#         "connection-string"
+#     ] = "zenml_test_connection_string"
+#     expected_outputs_json["pipeline"]["server-password"] = "zen_server_password"
+
+#     expected_output = json.dumps(expected_outputs_json, indent=2)
+
+#     # Invoke get command
+#     result = runner.invoke(app, ["get", "--output", "json", "--show-sensitive"])
+
+#     # Exit code 0 means there was no error
+#     assert result.exit_code == 0
+#     # Assert JSON is present and correct in cli output
+#     assert expected_output in result.stdout
+
+#     mock_provisioned_remote_state.use_lock.assert_called_once()
+
+
+# def test_cli_get_command_yaml_show_sensitive(
+#     runner: CliRunner,
+#     expected_output_lines_yaml: List[str],
+#     mock_provisioned_remote_state: MagicMock,
+# ):
+#     """Test cli get command default in YAML output with `show-sensitive` option specified..
+
+#     Args:
+#         runner (CliRunner): typer CLI runner
+#         expected_output_lines_yaml (List[str]): expected output with sensitive value hidden in yaml output format
+#         mock_provisioned_remote_state (MagicMock): mock of an RemoteStateManager instance
+#     """
+#     # Override fixture to expose sensitive value.
+#     expected_output_lines_yaml[4] = "connection-string: zenml_test_connection_string"
+#     expected_output_lines_yaml[6] = "server-password: zen_server_password"
+
+#     # Invoke get command
+#     result = runner.invoke(app, ["get", "--output", "yaml", "--show-sensitive"])
+
+#     # Exit code 0 means there was no error
+#     assert result.exit_code == 0
+#     # Assert YAML is present and correct in cli output
+#     for line in expected_output_lines_yaml:
+#         assert line in result.stdout
+
+#     mock_provisioned_remote_state.use_lock.assert_called_once()
+
+
+# def test_cli_get_command_no_show_sensitive_with_sensitive_resource(
+#     runner: CliRunner,
+#     expected_output_lines: List[str],
+#     mock_provisioned_remote_state: MagicMock,
+# ):
+#     """Test cli get command for when getting resource with sensitive value with no `show-sensitive` option specified.
+
+#     Args:
+#         runner (CliRunner): typer CLI runner
+#         expected_output_lines (List[str]): expected output with sensitive value hidden
+#         mock_provisioned_remote_state (MagicMock): mock of an RemoteStateManager instance
+#     """
+#     result = runner.invoke(app, ["get", "pipeline"])
+
+#     # Exit code 0 means there was no error
+#     assert result.exit_code == 0
+
+#     # expected_output_lines[:5] does not include experiment tracker.
+#     for line in expected_output_lines[:5]:
+#         assert line in result.stdout
+
+#     # expected_output_lines[5:] checks experiment tracker not in output.
+#     for line in expected_output_lines[5:]:
+#         assert line not in result.stdout
+
+#     mock_provisioned_remote_state.use_lock.assert_called_once()
+
+
+# def test_cli_get_command_show_sensitive_with_resource(
+#     runner: CliRunner,
+#     expected_output_lines: List[str],
+#     mock_provisioned_remote_state: MagicMock,
+# ):
+#     """Test cli get command for when getting resource with sensitive value with `show-sensitive` option specified.
+
+#     Args:
+#         runner (CliRunner): typer CLI runner
+#         expected_output_lines (List[str]): expected output with sensitive value hidden
+#         mock_provisioned_remote_state (MagicMock): mock of an RemoteStateManager instance
+#     """
+#     result = runner.invoke(app, ["get", "pipeline", "--show-sensitive"])
+
+#     # Override fixture to expose sensitive value.
+#     expected_output_lines[2] = "- connection-string: zenml_test_connection_string"
+#     expected_output_lines[3] = "- server-password: zen_server_password"
+
+#     # Exit code 0 means there was no error
+#     assert result.exit_code == 0
+
+#     # expected_output_lines[:5] does not include experiment tracker.
+#     for line in expected_output_lines[:5]:
+#         assert line in result.stdout
+
+#     # expected_output_lines[5:] checks experiment tracker not in output.
+#     for line in expected_output_lines[5:]:
+#         assert line not in result.stdout
+
+#     mock_provisioned_remote_state.use_lock.assert_called_once()

--- a/tests/test_cli/test_get.py
+++ b/tests/test_cli/test_get.py
@@ -20,6 +20,9 @@ def mock_provisioned_remote_state() -> Iterable[MagicMock]:
     with patch("matcha_ml.cli.cli.RemoteStateManager") as mock_state_manager_class:
         mock_state_manager = mock_state_manager_class.return_value
         mock_state_manager.is_state_provisioned.return_value = True
+        mock_state_manager.get_local_state_hash.return_value = (
+            "470544910b3fe623e00d63e6314588a3"
+        )
         yield mock_state_manager
 
 
@@ -153,27 +156,27 @@ def test_cli_get_command_with_no_state_file(
     mock_provisioned_remote_state.use_lock.assert_not_called()
 
 
-# def test_cli_get_command_hide_sensitive(
-#     runner: CliRunner,
-#     expected_output_lines: List[str],
-#     mock_provisioned_remote_state: MagicMock,
-# ):
-#     """Test cli get command when getting all resources with no `show-sensitive` option specified.
+def test_cli_get_command_hide_sensitive(
+    runner: CliRunner,
+    expected_output_lines: List[str],
+    mock_provisioned_remote_state: MagicMock,
+):
+    """Test cli get command when getting all resources with no `show-sensitive` option specified.
 
-#     Args:
-#         runner (CliRunner): typer CLI runner
-#         expected_output_lines (List[str]): expected output with sensitive value hidden
-#         mock_provisioned_remote_state (MagicMock): mock of an RemoteStateManager instance
-#     """
-#     result = runner.invoke(app, ["get"])
+    Args:
+        runner (CliRunner): typer CLI runner
+        expected_output_lines (List[str]): expected output with sensitive value hidden
+        mock_provisioned_remote_state (MagicMock): mock of an RemoteStateManager instance
+    """
+    result = runner.invoke(app, ["get"])
 
-#     # Exit code 0 means there was no error
-#     assert result.exit_code == 0
+    # Exit code 0 means there was no error
+    assert result.exit_code == 0
 
-#     for line in expected_output_lines:
-#         assert line in result.stdout
+    for line in expected_output_lines:
+        assert line in result.stdout
 
-#     mock_provisioned_remote_state.use_lock.assert_called_once()
+    mock_provisioned_remote_state.use_lock.assert_called_once()
 
 
 # def test_cli_get_command_show_sensitive(

--- a/tests/test_cli/test_get.py
+++ b/tests/test_cli/test_get.py
@@ -148,9 +148,9 @@ def test_cli_get_command_with_no_state_file(
     result = runner.invoke(app, ["get"])
 
     assert result.exit_code == 0
-    assert "Error - matcha.state file does not exist at" in str(result.stdout)
+    assert "Error - matcha state file does not exist at" in str(result.stdout)
 
-    mock_provisioned_remote_state.use_lock.assert_called_once()
+    mock_provisioned_remote_state.use_lock.assert_not_called()
 
 
 # def test_cli_get_command_hide_sensitive(

--- a/tests/test_cli/test_get.py
+++ b/tests/test_cli/test_get.py
@@ -23,6 +23,7 @@ def mock_provisioned_remote_state() -> Iterable[MagicMock]:
         mock_state_manager.get_hash_remote_state.return_value = (
             "470544910b3fe623e00d63e6314588a3"
         )
+        mock_state_manager.use_lock.return_value = MagicMock()
         yield mock_state_manager
 
 

--- a/tests/test_state/test_matcha_state.py
+++ b/tests/test_state/test_matcha_state.py
@@ -120,3 +120,15 @@ def test_check_state_file_does_not_exist(matcha_state_service: MatchaStateServic
 
     result = matcha_state_service.check_state_file_exists()
     assert result is False
+
+
+def test_get_hash_local_state(matcha_state_service: MatchaStateService):
+    """Test get hash of the local state file.
+
+    Args:
+        matcha_state_service (MatchaStateService): The matcha_state_service testing instance.
+    """
+    expected_hash = "031318ef84db0275c7d26230a51eb459"
+    result_hash = matcha_state_service.get_hash_local_state()
+
+    assert result_hash == expected_hash


### PR DESCRIPTION
Instead of downloading `.matcha` folder everytime we run `matcha get` command as mentioned in architecture diagram. An efficient approach would be to compare the hash of contents of the local matcha state and remote matcha state, download the entire `.matcha` folder only if the hash is different.

In this PR, we implement this verification on local and remote matcha state files.

Time Comparisions for running `matcha get` command

- On `develop` branch, adding `use_remote_state()` [here](https://github.com/fuzzylabs/matcha/blob/develop/src/matcha_ml/cli/cli.py#L93) i.e. download `.matcha` from remote every time we run get command  ~ 30 secs

![Screenshot from 2023-06-02 13-50-18](https://github.com/fuzzylabs/matcha/assets/10743098/b9fcd9e9-4c74-4e15-83fd-a0e2328f0c77)

- On `develop` branch, reading the local `matcha.state`  ~ 5-8 sec

![Screenshot from 2023-06-02 13-51-08](https://github.com/fuzzylabs/matcha/assets/10743098/35e76bc7-d003-499f-8ff9-b6492d0cff76)


- Current branch, verifying hash and then reading local `matcha.state` ~ 6-8 sec

![Screenshot from 2023-06-02 13-51-46](https://github.com/fuzzylabs/matcha/assets/10743098/3730371c-9e7b-4a91-bb25-0c1fda5a075e)


## Checklist

Please ensure you have done the following:

* [x] I have read the [CONTRIBUTING](https://github.com/fuzzylabs/matcha/blob/main/CONTRIBUTING.md) guide.
* [ ] I have updated the documentation if required.
* [x] I have added tests which cover my changes.

## Type of change

Tick all those that apply:

* [ ] Bug Fix (non-breaking change, fixing an issue)
* [x] New feature (non-breaking change to add functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Other (add details above)
