### PR TITLE
[RPD-238] [BUG] Stop matcha.lock file from being created in the users local directory

### DIFF
--- a/src/matcha_ml/constants.py
+++ b/src/matcha_ml/constants.py
@@ -1,0 +1,2 @@
+"""General constants file."""
+LOCK_FILE_NAME = "matcha.lock"

--- a/src/matcha_ml/state/remote_state_manager.py
+++ b/src/matcha_ml/state/remote_state_manager.py
@@ -15,10 +15,10 @@ from matcha_ml.cli.ui.status_message_builders import (
 from matcha_ml.errors import MatchaError
 from matcha_ml.runners import RemoteStateRunner
 from matcha_ml.storage import AzureStorage
+from matcha_ml.storage.azure_storage import LOCK_FILE_NAME
 from matcha_ml.templates import RemoteStateTemplate
 
 DEFAULT_CONFIG_NAME = "matcha.config.json"
-LOCK_FILE_NAME = "matcha.lock"
 ALREADY_LOCKED_MESSAGE = (
     "Remote state is already locked, maybe someone else is using matcha?"
     "If you think this is a mistake, you can unlock the state by running 'matcha force-unlock'."

--- a/src/matcha_ml/state/remote_state_manager.py
+++ b/src/matcha_ml/state/remote_state_manager.py
@@ -12,10 +12,10 @@ from matcha_ml.cli.ui.status_message_builders import (
     build_step_success_status,
     build_warning_status,
 )
+from matcha_ml.constants import LOCK_FILE_NAME
 from matcha_ml.errors import MatchaError
 from matcha_ml.runners import RemoteStateRunner
 from matcha_ml.storage import AzureStorage
-from matcha_ml.storage.azure_storage import LOCK_FILE_NAME
 from matcha_ml.templates import RemoteStateTemplate
 
 DEFAULT_CONFIG_NAME = "matcha.config.json"

--- a/src/matcha_ml/storage/azure_storage.py
+++ b/src/matcha_ml/storage/azure_storage.py
@@ -125,6 +125,8 @@ class AzureStorage:
         container_client = self._get_container_client(container_name)
 
         for blob in container_client.list_blobs():
+            if "matcha.lock" in str(blob.name):
+                continue
             blob_client = container_client.get_blob_client(blob=str(blob.name))
             file_path = os.path.join(dest_folder_path, str(blob.name))
 
@@ -202,6 +204,9 @@ class AzureStorage:
 
         # Remove blobs that are not present in the local `src_folder_path``
         for blob in blob_set:
+            # Ensure that the lock file is not being prematurely removed from the remote bucket
+            if "matcha.lock" in blob:
+                continue
             container_client.delete_blob(blob)
 
     def _sync_local(self, dest_folder_path: str) -> None:

--- a/src/matcha_ml/storage/azure_storage.py
+++ b/src/matcha_ml/storage/azure_storage.py
@@ -5,10 +5,10 @@ from typing import Set
 
 from azure.storage.blob import BlobClient, BlobServiceClient, ContainerClient
 
+from matcha_ml.constants import LOCK_FILE_NAME
 from matcha_ml.services.azure_service import AzureClient
 
 IGNORE_FOLDERS = [".terraform"]
-LOCK_FILE_NAME = "matcha.lock"
 
 
 class AzureStorage:

--- a/src/matcha_ml/storage/azure_storage.py
+++ b/src/matcha_ml/storage/azure_storage.py
@@ -8,6 +8,7 @@ from azure.storage.blob import BlobClient, BlobServiceClient, ContainerClient
 from matcha_ml.services.azure_service import AzureClient
 
 IGNORE_FOLDERS = [".terraform"]
+LOCK_FILE_NAME = "matcha.lock"
 
 
 class AzureStorage:
@@ -125,7 +126,7 @@ class AzureStorage:
         container_client = self._get_container_client(container_name)
 
         for blob in container_client.list_blobs():
-            if "matcha.lock" in str(blob.name):
+            if LOCK_FILE_NAME in str(blob.name):
                 continue
             blob_client = container_client.get_blob_client(blob=str(blob.name))
             file_path = os.path.join(dest_folder_path, str(blob.name))
@@ -205,7 +206,7 @@ class AzureStorage:
         # Remove blobs that are not present in the local `src_folder_path``
         for blob in blob_set:
             # Ensure that the lock file is not being prematurely removed from the remote bucket
-            if "matcha.lock" in blob:
+            if LOCK_FILE_NAME in blob:
                 continue
             container_client.delete_blob(blob)
 

--- a/tests/test_storage/test_azure_storage.py
+++ b/tests/test_storage/test_azure_storage.py
@@ -467,6 +467,7 @@ def test_sync_remote_does_not_remove_matcha_lock_from_remote_storage(
 
     az_storage._sync_remote("testcontainer", mock_blob_set)
 
+    # Check that the delete_blob method is not called with the 'matcha.lock' file
     mock_container_client.delete_blob.assert_called_once_with("blob_1")
 
 

--- a/tests/test_storage/test_azure_storage.py
+++ b/tests/test_storage/test_azure_storage.py
@@ -527,4 +527,4 @@ def test_download_folder_does_not_retrieve_matcha_lock_file(
 
         # Check that the matcha.lock file does not exist in local but "file_only_exist_azure" does
         assert "matcha.lock" not in os.listdir(matcha_testing_directory)
-        assert "file_only_exist_azure" not in os.listdir(matcha_testing_directory)
+        assert "file_only_exist_azure" in os.listdir(matcha_testing_directory)


### PR DESCRIPTION
After running provision a matcha.lock file is created in the users local directory. This is not meant to happen as the lock file is only meant to exist on the Azure blob storage.

This bug is due to the way we sync a user's local files with the Azure blob storage. When we sync and download the remote state, the matcha.lock file exists on Azure, hence we download that. To fix this we ignore `matcha.lock` on downloading.

Another bug exists where after `matcha provision` has completed, due to the `matcha.lock` file not existing within the user’s `.matcha` folder, the `matcha.lock` file is removed from the remote blob storage when syncing at the end of the provision command and the user is given the warning Tried unlocking state, but it was not locked. 

This is fixed by updating the `_sync_remote` function to ignore the possible removal of a `matcha.lock` file.

## Checklist

Please ensure you have done the following:

* [x] I have read the [CONTRIBUTING](https://github.com/fuzzylabs/matcha/blob/main/CONTRIBUTING.md) guide.
* [x] I have updated the documentation if required.
* [x] I have added tests which cover my changes.

## Type of change

Tick all those that apply:

* [x] Bug Fix (non-breaking change, fixing an issue)
* [ ] New feature (non-breaking change to add functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Other (add details above)
