### PR TITLE
[RPD-233] Change the matcha-ml global variable config location from a users home folder

### DIFF
--- a/src/matcha_ml/services/global_parameters_service.py
+++ b/src/matcha_ml/services/global_parameters_service.py
@@ -119,8 +119,9 @@ class GlobalParameters:
         Returns:
             The default global configuration directory.
         """
-        home_path = os.path.expanduser("~")
-        return os.path.join(home_path, ".matcha-ml", "config.yaml")
+        config_path = os.path.join(os.path.expanduser("~"), ".config")
+
+        return os.path.join(config_path, "matcha-ml", "config.yaml")
 
     @property
     def config_file(self) -> Dict[str, Any]:

--- a/tests/test_services/test_global_parameters_service.py
+++ b/tests/test_services/test_global_parameters_service.py
@@ -18,6 +18,19 @@ def teardown_singleton():
     GlobalParameters._instance = None
 
 
+@pytest.fixture
+def config_path(matcha_testing_directory) -> str:
+    """The location for the configuration as a fixture.
+
+    Args:
+        matcha_testing_directory (str): a mock testing directory, created for testing purposes
+
+    Returns:
+        str: the path for the config.
+    """
+    return os.path.join(matcha_testing_directory, ".config", "matcha-ml", "config.yaml")
+
+
 def test_class_is_singleton(matcha_testing_directory):
     """Tests that the GlobalParameters is correctly implemented as a singleton.
 
@@ -29,7 +42,9 @@ def test_class_is_singleton(matcha_testing_directory):
         new_callable=mock.PropertyMock,
     ) as file_path:
         file_path.return_value = str(
-            os.path.join(str(matcha_testing_directory), ".matcha-ml", "config.yaml")
+            os.path.join(
+                str(matcha_testing_directory), ".config", "matcha-ml", "config.yaml"
+            )
         )
 
         first_instance = GlobalParameters()
@@ -40,54 +55,47 @@ def test_class_is_singleton(matcha_testing_directory):
         assert first_instance.analytics_opt_out is second_instance.analytics_opt_out
 
 
-def test_new_config_file_creation(matcha_testing_directory):
+def test_new_config_file_creation(config_path):
     """Tests that a new file is created if it does not exist when the global parameters object is instantiated.
 
     Args:
-        matcha_testing_directory (str): Mock testing directory location for the config file to be located
+        config_path (str): Mock testing directory location for the config file to be located
     """
-    config_file_path = os.path.join(
-        matcha_testing_directory, ".matcha-ml", "config.yaml"
-    )
     with mock.patch(
         f"{INTERNAL_FUNCTION_STUB}.default_config_file_path",
         new_callable=mock.PropertyMock,
     ) as file_path:
-        file_path.return_value = config_file_path
+        file_path.return_value = config_path
 
-        assert not os.path.exists(config_file_path)
+        assert not os.path.exists(config_path)
         _ = GlobalParameters()
-        assert os.path.exists(config_file_path)
+        assert os.path.exists(config_path)
 
 
-def test_existing_config_file(matcha_testing_directory, uuid_for_testing):
+def test_existing_config_file(config_path, uuid_for_testing):
     """Tests that the class variables are updated when there is an existing config file.
 
     Args:
-        matcha_testing_directory (str): Mock testing directory location for the config file to be located
+        config_path (str): Mock testing directory location for the config file to be located
         uuid_for_testing (uuid.UUID): a UUID which acts as a mock for the user_id
     """
-    config_file_path = os.path.join(
-        matcha_testing_directory, ".matcha-ml", "config.yaml"
-    )
-
     data = {
         "user_id": str(uuid_for_testing),
         "analytics_opt_out": False,
     }
 
     # Create the '.matcha-ml' config directory
-    os.makedirs(os.path.dirname(config_file_path), exist_ok=True)
+    os.makedirs(os.path.dirname(config_path), exist_ok=True)
 
     # Create config file and populate with the current class variables
-    with open(config_file_path, "w") as file:
+    with open(config_path, "w") as file:
         yaml.dump(data, file)
 
     with mock.patch(
         f"{INTERNAL_FUNCTION_STUB}.default_config_file_path",
         new_callable=mock.PropertyMock,
     ) as file_path:
-        file_path.return_value = config_file_path
+        file_path.return_value = config_path
 
         config_instance = GlobalParameters()
         assert config_instance.config_file == {
@@ -98,21 +106,17 @@ def test_existing_config_file(matcha_testing_directory, uuid_for_testing):
         assert config_instance.analytics_opt_out is False
 
 
-def test_opt_out(matcha_testing_directory):
+def test_opt_out(config_path):
     """Tests that the opt out function changes the class variables and the global config file.
 
     Args:
-        matcha_testing_directory (str): Mock testing directory location for the Global Parameteres file to be located
+        config_path (str): Mock testing directory location for the Global Parameteres file to be located
     """
-    config_file_path = os.path.join(
-        matcha_testing_directory, ".matcha-ml", "config.yaml"
-    )
-
     with mock.patch(
         f"{INTERNAL_FUNCTION_STUB}.default_config_file_path",
         new_callable=mock.PropertyMock,
     ) as file_path:
-        file_path.return_value = config_file_path
+        file_path.return_value = config_path
 
         config_instance = GlobalParameters()
 
@@ -125,20 +129,18 @@ def test_opt_out(matcha_testing_directory):
         assert config_instance.analytics_opt_out is True
 
 
-def test_config_file_write_permissions(matcha_testing_directory):
+def test_config_file_write_permissions(matcha_testing_directory, config_path):
     """Tests the permissions error thrown where the user does not have permission to write a config file.
 
     Args:
-        matcha_testing_directory (str): Mock testing directory location for the config file to be located
+        matcha_testing_directory (str): Mock testing directory.
+        config_path (str): the location in which the configuration will be stored.
     """
-    config_file_path = os.path.join(
-        matcha_testing_directory, ".matcha-ml", "config.yaml"
-    )
     with mock.patch(
         f"{INTERNAL_FUNCTION_STUB}.default_config_file_path",
         new_callable=mock.PropertyMock,
     ) as file_path:
-        file_path.return_value = config_file_path
+        file_path.return_value = config_path
 
         # Alters the permissions on the testing directory to be read-only
         os.chmod(matcha_testing_directory, S_IREAD)

--- a/tests/test_services/test_global_parameters_service.py
+++ b/tests/test_services/test_global_parameters_service.py
@@ -31,21 +31,17 @@ def config_path(matcha_testing_directory) -> str:
     return os.path.join(matcha_testing_directory, ".config", "matcha-ml", "config.yaml")
 
 
-def test_class_is_singleton(matcha_testing_directory):
+def test_class_is_singleton(config_path):
     """Tests that the GlobalParameters is correctly implemented as a singleton.
 
     Args:
-        matcha_testing_directory (str): Mock testing directory location for the config file to be located
+        config_path (str): Mock testing directory location for the config file to be located
     """
     with mock.patch(
         f"{INTERNAL_FUNCTION_STUB}.default_config_file_path",
         new_callable=mock.PropertyMock,
     ) as file_path:
-        file_path.return_value = str(
-            os.path.join(
-                str(matcha_testing_directory), ".config", "matcha-ml", "config.yaml"
-            )
-        )
+        file_path.return_value = config_path
 
         first_instance = GlobalParameters()
         second_instance = GlobalParameters()


### PR DESCRIPTION
This PR makes Matcha POSIX compliant. More specifically, the prior location of the global configuration file was in a `.matcha-ml` directory in the users home directory - this goes against POSIX principles. In this PR, that location is changed in the code to the `.config` directory in the home directory and `.matcha-ml` is no longer a hidden directory.

## Checklist

Please ensure you have done the following:

* [x] I have read the [CONTRIBUTING](https://github.com/fuzzylabs/matcha/blob/main/CONTRIBUTING.md) guide.
* [ ] I have updated the documentation if required.
* [x] I have added tests which cover my changes.

## Type of change

Tick all those that apply:

* [ ] Bug Fix (non-breaking change, fixing an issue)
* [ ] New feature (non-breaking change to add functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Other (add details above)
