### PR TITLE
[RPD-240] `matcha destroy` command does not work in remote scenraio

### DIFF
--- a/src/matcha_ml/cli/cli.py
+++ b/src/matcha_ml/cli/cli.py
@@ -119,7 +119,7 @@ def destroy(
     else:
         print_status(
             build_warning_status(
-                "Warning: a storage container holding Matcha state information will persist. To destroy ALL clound resources, run 'matcha destroy full'."
+                "Warning: a storage container holding Matcha state information will persist. To destroy ALL cloud resources, run 'matcha destroy full'."
             )
         )
         destroy_resources(resources=RESOURCE_MSG)

--- a/src/matcha_ml/runners/azure_runner.py
+++ b/src/matcha_ml/runners/azure_runner.py
@@ -150,5 +150,6 @@ class AzureRunner(BaseRunner):
         """Destroy the provisioned resources."""
         self._check_matcha_directory_exists()
         self._check_terraform_installation()
+        self._initialize_terraform(msg="Matcha")
         self._destroy_terraform(msg="Matcha")
         self._write_outputs_state_cloud_only()

--- a/src/matcha_ml/runners/remote_state_runner.py
+++ b/src/matcha_ml/runners/remote_state_runner.py
@@ -70,5 +70,6 @@ class RemoteStateRunner(BaseRunner):
         """Destroy the provisioned resources."""
         self._check_matcha_directory_exists()
         self._check_terraform_installation()
+        self._initialize_terraform(msg="Remote State")
         self._destroy_terraform(msg="Remote State")
         self._clean_up()

--- a/src/matcha_ml/services/terraform_service.py
+++ b/src/matcha_ml/services/terraform_service.py
@@ -118,13 +118,12 @@ class TerraformService:
         return Path(self.config.var_file).exists()
 
     def get_tf_state_dir(self) -> Path:
-        """Get the path of the terraform.tfstate file generated on completion of `terraform init`.
+        """Get the path to the `.terraform` folder generated on completion of `terraform init`.
 
         Returns:
-            Path: a Path object that represents the path to the terraform.tfstate file
-        directory.
+            Path: a Path object that represents the path to the `.terraform` folder.
         """
-        return Path(os.path.join(self.config.working_dir, "terraform.tfstate"))
+        return Path(os.path.join(self.config.working_dir, ".terraform"))
 
     def init(self) -> Tuple[int, str, str]:
         """Run `terraform init` with the initialised Terraform client from the python_terraform module.

--- a/tests/test_runners/test_azure_runner.py
+++ b/tests/test_runners/test_azure_runner.py
@@ -266,6 +266,7 @@ def test_deprovision(
     """
     template_runner._check_terraform_installation = MagicMock()
     template_runner._check_matcha_directory_exists = MagicMock()
+    template_runner._initialize_terraform = MagicMock()
     template_runner._destroy_terraform = MagicMock()
     matcha_state_file_dir = os.path.join(
         matcha_testing_directory, ".matcha", "infrastructure", "matcha.state"

--- a/tests/test_runners/test_remote_state_runner.py
+++ b/tests/test_runners/test_remote_state_runner.py
@@ -115,6 +115,7 @@ def test_deprovision(
 
     template_runner._check_terraform_installation = MagicMock()
     template_runner._check_matcha_directory_exists = MagicMock()
+    template_runner._initialize_terraform = MagicMock()
     template_runner._destroy_terraform = MagicMock()
 
     with mock.patch("typer.confirm") as mock_confirm:

--- a/tests/test_services/test_terraform_service.py
+++ b/tests/test_services/test_terraform_service.py
@@ -189,13 +189,13 @@ def test_validate_config_not_exist(terraform_test_config: TerraformConfig):
 
 
 def test_get_tf_state_dir(tmp_path, terraform_test_config: TerraformConfig):
-    """Test get_previous_temp_dir returns the path of the terraform.tfstate file.
+    """Test get_previous_temp_dir returns the path of the .terraform folder.
 
     Args:
         tmp_path (str): Pytest temporary path fixture for testing.
         terraform_test_config (TerraformConfig): test terraform service config.
     """
-    new_dir = tmp_path / "terraform.tfstate"
+    new_dir = tmp_path / ".terraform"
     os.mkdir(new_dir)
 
     tfs = TerraformService(terraform_test_config)
@@ -205,7 +205,7 @@ def test_get_tf_state_dir(tmp_path, terraform_test_config: TerraformConfig):
     # Extract the last component of the path otherwise it will return full path
     last_component = os.path.basename(path)
 
-    assert last_component == "terraform.tfstate"
+    assert last_component == ".terraform"
 
 
 def test_init(terraform_test_config: TerraformConfig):


### PR DESCRIPTION
Consider  a scenario where one user has created the resources and other user is trying to destroy resource. This is currently not supported in matcha.

The issue arises as we are not uploading terraform cache stored inside .terraform folder. The other user will only download the terraform files and will not have `.terraform` folder. This folder is created using `terraform ini`t command or `_initialize_terraform` inside matcha.

We implement a fix in this PR by calling init function while destroying the resources for both `RemoteState` and `Azure` runners.

## Checklist

Please ensure you have done the following:

* [x] I have read the [CONTRIBUTING](https://github.com/fuzzylabs/matcha/blob/main/CONTRIBUTING.md) guide.
* [ ] I have updated the documentation if required.
* [x] I have added tests which cover my changes.

## Type of change

Tick all those that apply:

* [ ] Bug Fix (non-breaking change, fixing an issue)
* [ ] New feature (non-breaking change to add functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Other (add details above)
