### PR TITLE
[RPD-191] Add an init to core to enable a cleaner import

### DIFF
--- a/src/matcha_ml/cli/cli.py
+++ b/src/matcha_ml/cli/cli.py
@@ -3,7 +3,7 @@ from typing import Optional
 
 import typer
 
-from matcha_ml import __version__
+from matcha_ml import __version__, core
 from matcha_ml.cli._validation import (
     prefix_typer_callback,
     region_typer_callback,
@@ -20,7 +20,6 @@ from matcha_ml.cli.ui.resource_message_builders import (
     build_resource_output,
     hide_sensitive_in_output,
 )
-from matcha_ml.core import core
 from matcha_ml.errors import MatchaError, MatchaInputError
 from matcha_ml.services.analytics_service import AnalyticsEvent, track
 from matcha_ml.state import RemoteStateManager

--- a/src/matcha_ml/core/__init__.py
+++ b/src/matcha_ml/core/__init__.py
@@ -1,0 +1,4 @@
+"""Matcha core functionality module."""
+from .core import analytics_opt_in, analytics_opt_out, get, remove_state_lock
+
+__all__ = ["get", "analytics_opt_in", "analytics_opt_out", "remove_state_lock"]

--- a/tests/test_cli/test_analytics.py
+++ b/tests/test_cli/test_analytics.py
@@ -5,7 +5,7 @@ from typer.testing import CliRunner
 
 from matcha_ml.cli.cli import app
 
-INTERNAL_FUNCTION_STUB = "matcha_ml.core.core"
+INTERNAL_FUNCTION_STUB = "matcha_ml.core"
 
 
 def test_cli_analytics_command_help_option(runner: CliRunner) -> None:

--- a/tests/test_cli/test_force_unlock.py
+++ b/tests/test_cli/test_force_unlock.py
@@ -1,10 +1,11 @@
 """Test suite for matcha cli force-unlock command."""
 from unittest.mock import patch
+
 from typer.testing import CliRunner
 
 from matcha_ml.cli.cli import app
 
-INTERNAL_FUNCTION_STUB = "matcha_ml.core.core"
+INTERNAL_FUNCTION_STUB = "matcha_ml.core"
 
 
 def test_cli_force_unlock_command_help_option(runner: CliRunner) -> None:

--- a/tests/test_core/test_core.py
+++ b/tests/test_core/test_core.py
@@ -9,7 +9,7 @@ import pytest
 import yaml
 
 from matcha_ml.cli.cli import app
-from matcha_ml.core.core import get, remove_state_lock
+from matcha_ml.core import get, remove_state_lock
 from matcha_ml.errors import MatchaInputError
 from matcha_ml.services.global_parameters_service import GlobalParameters
 


### PR DESCRIPTION
Currently, the imports from the `core` module are convoluted. To fix this we add the functions to an `init` file within the `core` directory and update the imports accordingly. 

This also means if a user wants to run this in an API session they can simply use the command:

```
import matcha_ml.core as matcha

matcha.provision(...)
matcha.get(...)
...
```

## Checklist

Please ensure you have done the following:

* [x] I have read the [CONTRIBUTING](https://github.com/fuzzylabs/matcha/blob/main/CONTRIBUTING.md) guide.
* [ ] I have updated the documentation if required.
* [ ] I have added tests which cover my changes.

## Type of change

Tick all those that apply:

* [ ] Bug Fix (non-breaking change, fixing an issue)
* [x] New feature (non-breaking change to add functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Other (add details above)
