### PR TITLE
[RPD-244] Add CI to feature branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,10 +6,12 @@ on:
     branches:
       - main
       - develop
+      - '**feature**'
   push:
     branches:
       - main
       - develop
+      - '**feature**'
 
 jobs:
   ci-tests:


### PR DESCRIPTION
Currently, GitHub CI does not run on branches merging into feature branches. This pr fixes this by updating the CI from:

```
on:
  workflow_call:
  pull_request:
    branches:
      - main
      - develop

  push:
    branches:
      - main
      - develop
```

to:

```
on:
  workflow_call:
  pull_request:
    branches:
      - main
      - develop
      - '**feature**'

  push:
    branches:
      - main
      - develop
      - '**feature**'
```

Which will match any branch that contains the word feature at any position in the branch name. In the future, we may want to specify feature branches in a different way such as `feature/RPD-xxx-implement-xyz`

## Checklist

Please ensure you have done the following:

* [x] I have read the [CONTRIBUTING](https://github.com/fuzzylabs/matcha/blob/main/CONTRIBUTING.md) guide.
* [x] I have updated the documentation if required.
* [ ] I have added tests which cover my changes.

## Type of change

Tick all those that apply:

* [x] Bug Fix (non-breaking change, fixing an issue)
* [x] New feature (non-breaking change to add functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Other (add details above)
