### PR TITLE
[WIP] [RPD-197] Refactor `get` to return `MatchaState` object

### DIFF
--- a/tests/test_state/test_matcha_state.py
+++ b/tests/test_state/test_matcha_state.py
@@ -5,6 +5,12 @@ import os
 import pytest
 
 from matcha_ml.state import MatchaStateService
+from matcha_ml.state.matcha_state import (
+    MatchaResource,
+    MatchaResourceProperty,
+    MatchaState,
+    MatchaStateComponent,
+)
 
 
 @pytest.fixture
@@ -64,6 +70,57 @@ def expected_outputs() -> dict:
     return outputs
 
 
+@pytest.fixture
+def state_file_as_object() -> MatchaState:
+    """A fixture to represent the Matcha state as a MatchaState object.
+
+    Returns:
+        MatchaState: the Matcha state testing fixture.
+    """
+    return MatchaState(
+        components=[
+            MatchaStateComponent(
+                resource=MatchaResource("cloud"),
+                properties=[
+                    MatchaResourceProperty("flavor", "azure"),
+                    MatchaResourceProperty("resource-group-name", "test_resources"),
+                ],
+            ),
+            MatchaStateComponent(
+                resource=MatchaResource("container-registry"),
+                properties=[
+                    MatchaResourceProperty("flavor", "azure"),
+                    MatchaResourceProperty("registry-name", "azure_registry_name"),
+                    MatchaResourceProperty("registry-url", "azure_container_registry"),
+                ],
+            ),
+            MatchaStateComponent(
+                resource=MatchaResource("experiment-tracker"),
+                properties=[
+                    MatchaResourceProperty("flavor", "mlflow"),
+                    MatchaResourceProperty("tracking-url", "mlflow_test_url"),
+                ],
+            ),
+        ]
+    )
+
+
+@pytest.fixture
+def experiment_tracker_state_component() -> MatchaStateComponent:
+    """A single state component as a fixture, specifically, the experiment-tracker.
+
+    Returns:
+        MatchaStateComponent: the experiment tracker state component.
+    """
+    return MatchaStateComponent(
+        resource=MatchaResource("experiment-tracker"),
+        properties=[
+            MatchaResourceProperty("flavor", "mlflow"),
+            MatchaResourceProperty("tracking-url", "mlflow_test_url"),
+        ],
+    )
+
+
 def test_state_file_getter(
     matcha_state_service: MatchaStateService, expected_outputs: dict
 ):
@@ -77,8 +134,8 @@ def test_state_file_getter(
     assert result == expected_outputs
 
 
-def test_fetch_resources_from_state_file(
-    matcha_state_service: MatchaStateService, expected_outputs: dict
+def test_fetch_resources_from_state_file_full(
+    matcha_state_service: MatchaStateService, state_file_as_object: MatchaState
 ):
     """Test whether the fetch_resources_from_state_file function is able to return resource specified by the resource name.
 
@@ -86,16 +143,47 @@ def test_fetch_resources_from_state_file(
 
     Args:
         matcha_state_service (MatchaStateService): The matcha_state_service testing instance.
-        expected_outputs (dict): The expected state file.
+        state_file_as_object (MatchaState): The state file represented as a MatchaState object.
     """
-    result = matcha_state_service.fetch_resources_from_state_file()
-    assert result == expected_outputs
+    state = matcha_state_service.fetch_resources_from_state_file()
+    assert state == state_file_as_object
 
-    result = matcha_state_service.fetch_resources_from_state_file(
-        resource_name="experiment-tracker", property_name="tracking-url"
+
+def test_fetch_resources_from_state_file_resource_only(
+    matcha_state_service: MatchaStateService,
+    experiment_tracker_state_component: MatchaStateComponent,
+):
+    """Test whether fetching resources just using the resource name returns the expected result.
+
+    Args:
+        matcha_state_service (MatchaStateService): The Matcha state service testing instance.
+        experiment_tracker_state_component (MatchaStateComponent): The experiment tracker state componment testing fixture.
+    """
+    property = matcha_state_service.fetch_resources_from_state_file(
+        resource_name="experiment-tracker", property_name=None
     )
-    expected = {"experiment-tracker": {"tracking-url": "mlflow_test_url"}}
-    assert result == expected
+
+    assert property.components and len(property.components) == 1
+
+    assert property.components[0] == experiment_tracker_state_component
+
+
+def test_fetch_resources_from_state_file_with_resource_and_property(
+    matcha_state_service: MatchaStateService,
+    experiment_tracker_state_component: MatchaStateComponent,
+):
+    """Test whether fetching resources using both the resource name and property name returns the expected result.
+
+    Args:
+        matcha_state_service (MatchaStateService): The Matcha state service testing instance.
+        experiment_tracker_state_component (MatchaStateComponent): The experiment tracker state component testing fixture.
+    """
+    state = matcha_state_service.fetch_resources_from_state_file(
+        resource_name="experiment-tracker", property_name="flavor"
+    )
+    assert state.components and len(state.components) == 1
+
+    state.components[0] == experiment_tracker_state_component
 
 
 def test_check_state_file_exists(matcha_state_service: MatchaStateService):
@@ -132,3 +220,57 @@ def test_get_hash_local_state(matcha_state_service: MatchaStateService):
     result_hash = matcha_state_service.get_hash_local_state()
 
     assert result_hash == expected_hash
+
+
+def test_get_resource_names_expected(matcha_state_service: MatchaStateService):
+    """Test that getting the resource names returns the expected results.
+
+    Args:
+        matcha_state_service (MatchaStateService): The Matcha state service testing instance.
+    """
+    assert "cloud" in matcha_state_service.get_resource_names()
+
+
+def test_get_resource_names_resource_not_present(
+    matcha_state_service: MatchaStateService,
+):
+    """Test that the correct names are being returned by the get resource names function.
+
+    Args:
+        matcha_state_service (MatchaStateService): The Matcha state service testing instance.
+    """
+    assert "not a resource" not in matcha_state_service.get_resource_names()
+
+
+def test_convert_to_matcha_state_object(
+    matcha_state_service: MatchaStateService, state_file_as_object: MatchaState
+):
+    """Test that converting the Matcha state to a MatchaState object works as expected.
+
+    Args:
+        matcha_state_service (MatchaStateService): The Matcha state service testing instance.
+        state_file_as_object (MatchaState): The Matcha state as a MatchaState object.
+    """
+
+    def _compare_object(
+        matcha_state_component: MatchaStateComponent, expected: MatchaStateComponent
+    ) -> bool:
+        """A utility function to test equality between two MatchaStateComponent objects.
+
+        Args:
+            matcha_state_component (MatchaStateComponent): the object being tested.
+            expected (MatchaStateComponent): the ground truth object.
+
+        Returns:
+            bool: True if they are equal, false otherwise.
+        """
+        return matcha_state_component == expected
+
+    state_object = matcha_state_service._convert_to_matcha_state_object(
+        matcha_state_service.state_file
+    )
+
+    for state_actual, state_expected in zip(
+        state_object.components, state_file_as_object.components
+    ):
+        assert _compare_object(state_actual, state_expected)


### PR DESCRIPTION
The current version of `core.get()` returns a dictionary with the form: `Dict[str, Dict[str, str]]` which is unclear to users of `get` in an API context. This PR updates this and introduces a `MatchaState` object to properly define the state and it's components.

To create the `MatchaState` object, three new objects are created that specify components of the state: `MatchaStateComponent`, `MatchaResourceProperty`, and `MatchaResource`.

To convert the state in it's current form (which is a dictionary of dictionaries), a utility function `_convert_to_matcha_state_object` has been created.

The necessary tests are refactored and new tests have been added.

Note: on the back of this PR, the `MatchaStateService` should be refactored to make use of the new objects defined in this ticket. This will be a separate PR.

## Checklist

Please ensure you have done the following:

* [ ] I have read the [CONTRIBUTING](https://github.com/fuzzylabs/matcha/blob/main/CONTRIBUTING.md) guide.
* [ ] I have updated the documentation if required.
* [ ] I have added tests which cover my changes.

## Type of change

Tick all those that apply:

* [ ] Bug Fix (non-breaking change, fixing an issue)
* [ ] New feature (non-breaking change to add functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Other (add details above)
