### PR TITLE
[RPD-193] Refactor `TemplateRunner.is_approved` into a UI function

### DIFF
--- a/src/matcha_ml/cli/destroy.py
+++ b/src/matcha_ml/cli/destroy.py
@@ -4,6 +4,7 @@ from typing import List, Tuple
 import typer
 
 from matcha_ml.cli._validation import check_current_deployment_exists
+from matcha_ml.cli.ui.functions import is_approved
 from matcha_ml.cli.ui.print_messages import print_error, print_status
 from matcha_ml.cli.ui.status_message_builders import (
     build_status,
@@ -41,7 +42,7 @@ def destroy_resources(resources: List[Tuple[str, str]]) -> None:
             )
             raise typer.Exit()
 
-        if template_runner.is_approved(verb="destroy", resources=resources):
+        if is_approved(verb="destroy", resources=resources):
             # deprovision the resources
             template_runner.deprovision()
             print_status(build_step_success_status("Destroying resources is complete!"))

--- a/src/matcha_ml/cli/destroy.py
+++ b/src/matcha_ml/cli/destroy.py
@@ -4,12 +4,12 @@ from typing import List, Tuple
 import typer
 
 from matcha_ml.cli._validation import check_current_deployment_exists
-from matcha_ml.cli.ui.functions import get_modify_resource_approval
 from matcha_ml.cli.ui.print_messages import print_error, print_status
 from matcha_ml.cli.ui.status_message_builders import (
     build_status,
     build_step_success_status,
 )
+from matcha_ml.cli.ui.user_approval_functions import is_user_approved
 from matcha_ml.runners import AzureRunner
 from matcha_ml.state import RemoteStateManager
 
@@ -42,7 +42,7 @@ def destroy_resources(resources: List[Tuple[str, str]]) -> None:
             )
             raise typer.Exit()
 
-        if get_modify_resource_approval(verb="destroy", resources=resources):
+        if is_user_approved(verb="destroy", resources=resources):
             # deprovision the resources
             template_runner.deprovision()
             print_status(build_step_success_status("Destroying resources is complete!"))

--- a/src/matcha_ml/cli/destroy.py
+++ b/src/matcha_ml/cli/destroy.py
@@ -4,7 +4,7 @@ from typing import List, Tuple
 import typer
 
 from matcha_ml.cli._validation import check_current_deployment_exists
-from matcha_ml.cli.ui.functions import is_approved
+from matcha_ml.cli.ui.functions import get_modify_resource_approval
 from matcha_ml.cli.ui.print_messages import print_error, print_status
 from matcha_ml.cli.ui.status_message_builders import (
     build_status,
@@ -42,7 +42,7 @@ def destroy_resources(resources: List[Tuple[str, str]]) -> None:
             )
             raise typer.Exit()
 
-        if is_approved(verb="destroy", resources=resources):
+        if get_modify_resource_approval(verb="destroy", resources=resources):
             # deprovision the resources
             template_runner.deprovision()
             print_status(build_step_success_status("Destroying resources is complete!"))

--- a/src/matcha_ml/cli/provision.py
+++ b/src/matcha_ml/cli/provision.py
@@ -6,13 +6,13 @@ import typer
 
 from matcha_ml.cli._validation import prefix_typer_callback, region_typer_callback
 from matcha_ml.cli.constants import RESOURCE_MSG
-from matcha_ml.cli.ui.functions import get_modify_resource_approval
 from matcha_ml.cli.ui.print_messages import print_status
 from matcha_ml.cli.ui.status_message_builders import (
     build_status,
     build_step_success_status,
     build_warning_status,
 )
+from matcha_ml.cli.ui.user_approval_functions import is_user_approved
 from matcha_ml.runners import AzureRunner
 from matcha_ml.state import RemoteStateManager
 from matcha_ml.templates import AzureTemplate
@@ -120,7 +120,7 @@ def provision_resources(
         azure_template.build_template(config, template, destination, verbose)
 
         # Initializes the infrastructure provisioning process.
-        if get_modify_resource_approval(verb="provision", resources=RESOURCE_MSG):
+        if is_user_approved(verb="provision", resources=RESOURCE_MSG):
             # provision resources by running the template
             template_runner.provision()
             print_status(build_step_success_status("Provisioning is complete!"))

--- a/src/matcha_ml/cli/provision.py
+++ b/src/matcha_ml/cli/provision.py
@@ -6,7 +6,7 @@ import typer
 
 from matcha_ml.cli._validation import prefix_typer_callback, region_typer_callback
 from matcha_ml.cli.constants import RESOURCE_MSG
-from matcha_ml.cli.ui.functions import is_approved
+from matcha_ml.cli.ui.functions import get_modify_resource_approval
 from matcha_ml.cli.ui.print_messages import print_status
 from matcha_ml.cli.ui.status_message_builders import (
     build_status,
@@ -120,7 +120,7 @@ def provision_resources(
         azure_template.build_template(config, template, destination, verbose)
 
         # Initializes the infrastructure provisioning process.
-        if is_approved(verb="provision", resources=RESOURCE_MSG):
+        if get_modify_resource_approval(verb="provision", resources=RESOURCE_MSG):
             # provision resources by running the template
             template_runner.provision()
             print_status(build_step_success_status("Provisioning is complete!"))

--- a/src/matcha_ml/cli/provision.py
+++ b/src/matcha_ml/cli/provision.py
@@ -6,6 +6,7 @@ import typer
 
 from matcha_ml.cli._validation import prefix_typer_callback, region_typer_callback
 from matcha_ml.cli.constants import RESOURCE_MSG
+from matcha_ml.cli.ui.functions import is_approved
 from matcha_ml.cli.ui.print_messages import print_status
 from matcha_ml.cli.ui.status_message_builders import (
     build_status,
@@ -119,7 +120,7 @@ def provision_resources(
         azure_template.build_template(config, template, destination, verbose)
 
         # Initializes the infrastructure provisioning process.
-        if template_runner.is_approved(verb="provision", resources=RESOURCE_MSG):
+        if is_approved(verb="provision", resources=RESOURCE_MSG):
             # provision resources by running the template
             template_runner.provision()
             print_status(build_step_success_status("Provisioning is complete!"))

--- a/src/matcha_ml/cli/ui/functions.py
+++ b/src/matcha_ml/cli/ui/functions.py
@@ -1,0 +1,38 @@
+'''UI functions.'''
+import typer
+
+from typing import List, Tuple
+
+from matcha_ml.cli.ui.emojis import Emojis
+from matcha_ml.cli.ui.print_messages import (
+    print_error,
+    print_json,
+    print_status,
+)
+from matcha_ml.cli.ui.resource_message_builders import (
+    dict_to_json,
+    hide_sensitive_in_output,
+)
+from matcha_ml.cli.ui.status_message_builders import (
+    build_resource_confirmation,
+    build_status,
+)
+
+def is_approved(verb: str, resources: List[Tuple[str, str]]) -> bool:
+    """Get approval from user within the CLI.
+
+    Args:
+        verb (str): the verb to use in the approval message.
+        resources(list): the list of resources to be actioned by the verb to be provided to the user as a status message
+
+    Returns:
+        bool: True if user approves, False otherwise.
+    """
+    summary_message = build_resource_confirmation(
+        header=f"The following resources will be {verb}ed",
+        resources=resources,
+        footer=f"{verb.capitalize()}ing the resources may take approximately 20 minutes. May we suggest you grab a cup of {Emojis.MATCHA.value}?",
+    )
+
+    print_status(summary_message)
+    return typer.confirm(f"Are you happy for '{verb}' to run?")

--- a/src/matcha_ml/cli/ui/functions.py
+++ b/src/matcha_ml/cli/ui/functions.py
@@ -12,7 +12,7 @@ from matcha_ml.cli.ui.status_message_builders import (
 )
 
 
-def is_approved(verb: str, resources: List[Tuple[str, str]]) -> bool:
+def get_modify_resource_approval(verb: str, resources: List[Tuple[str, str]]) -> bool:
     """Get approval from user within the CLI.
 
     Args:

--- a/src/matcha_ml/cli/ui/functions.py
+++ b/src/matcha_ml/cli/ui/functions.py
@@ -1,22 +1,16 @@
-'''UI functions.'''
-import typer
-
+"""UI functions."""
 from typing import List, Tuple
+
+import typer
 
 from matcha_ml.cli.ui.emojis import Emojis
 from matcha_ml.cli.ui.print_messages import (
-    print_error,
-    print_json,
     print_status,
-)
-from matcha_ml.cli.ui.resource_message_builders import (
-    dict_to_json,
-    hide_sensitive_in_output,
 )
 from matcha_ml.cli.ui.status_message_builders import (
     build_resource_confirmation,
-    build_status,
 )
+
 
 def is_approved(verb: str, resources: List[Tuple[str, str]]) -> bool:
     """Get approval from user within the CLI.

--- a/src/matcha_ml/cli/ui/user_approval_functions.py
+++ b/src/matcha_ml/cli/ui/user_approval_functions.py
@@ -1,4 +1,4 @@
-"""UI functions."""
+"""UI user approval functions."""
 from typing import List, Tuple
 
 import typer
@@ -12,7 +12,7 @@ from matcha_ml.cli.ui.status_message_builders import (
 )
 
 
-def get_modify_resource_approval(verb: str, resources: List[Tuple[str, str]]) -> bool:
+def is_user_approved(verb: str, resources: List[Tuple[str, str]]) -> bool:
     """Get approval from user within the CLI.
 
     Args:

--- a/src/matcha_ml/runners/azure_runner.py
+++ b/src/matcha_ml/runners/azure_runner.py
@@ -40,25 +40,6 @@ class AzureRunner(BaseRunner):
         """Initialize AzureRunner class."""
         super().__init__()
 
-    def is_approved(self, verb: str, resources: List[Tuple[str, str]]) -> bool:
-        """Get approval from user to modify resources on cloud.
-
-        Args:
-            verb (str): the verb to use in the approval message.
-            resources(list): the list of resources to be actioned by the verb to be provided to the user as a status message
-
-        Returns:
-            bool: True if user approves, False otherwise.
-        """
-        summary_message = build_resource_confirmation(
-            header=f"The following resources will be {verb}ed",
-            resources=resources,
-            footer=f"{verb.capitalize()}ing the resources may take approximately 20 minutes. May we suggest you grab a cup of {Emojis.MATCHA.value}?",
-        )
-
-        print_status(summary_message)
-        return typer.confirm(f"Are you happy for '{verb}' to run?")
-
     def _build_resource_output(self, output_name: str) -> Tuple[str, str, str]:
         """Build resource output for each Terraform output.
 

--- a/src/matcha_ml/runners/azure_runner.py
+++ b/src/matcha_ml/runners/azure_runner.py
@@ -2,11 +2,8 @@
 import json
 import uuid
 from collections import defaultdict
-from typing import Dict, List, Tuple
+from typing import Dict, Tuple
 
-import typer
-
-from matcha_ml.cli.ui.emojis import Emojis
 from matcha_ml.cli.ui.print_messages import (
     print_error,
     print_json,
@@ -17,7 +14,6 @@ from matcha_ml.cli.ui.resource_message_builders import (
     hide_sensitive_in_output,
 )
 from matcha_ml.cli.ui.status_message_builders import (
-    build_resource_confirmation,
     build_status,
 )
 from matcha_ml.errors import MatchaInputError

--- a/tests/test_cli/test_ui_functions.py
+++ b/tests/test_cli/test_ui_functions.py
@@ -1,13 +1,12 @@
 """Tests for cli.ui.functions."""
 
-import pytest
 from unittest import mock
 
 from matcha_ml.cli.ui.functions import is_approved
 
+
 def test_is_approved():
-    """Test if is_approved behaves as expected based on user's input.
-    """
+    """Test if is_approved behaves as expected based on user's input."""
     with mock.patch("typer.confirm") as mock_confirm:
         mock_confirm.return_value = True
         assert is_approved("provision", [])

--- a/tests/test_cli/test_ui_functions.py
+++ b/tests/test_cli/test_ui_functions.py
@@ -1,0 +1,16 @@
+"""Tests for cli.ui.functions."""
+
+import pytest
+from unittest import mock
+
+from matcha_ml.cli.ui.functions import is_approved
+
+def test_is_approved():
+    """Test if is_approved behaves as expected based on user's input.
+    """
+    with mock.patch("typer.confirm") as mock_confirm:
+        mock_confirm.return_value = True
+        assert is_approved("provision", [])
+
+        mock_confirm.return_value = False
+        assert not is_approved("provision", [])

--- a/tests/test_cli/test_ui_functions.py
+++ b/tests/test_cli/test_ui_functions.py
@@ -6,7 +6,7 @@ from matcha_ml.cli.ui.functions import get_modify_resource_approval
 
 
 def test_get_modify_resource_approvals():
-    """Test if is_approved behaves as expected based on user's input."""
+    """Test if get_modify_resource_approval behaves as expected based on user's input."""
     with mock.patch("typer.confirm") as mock_confirm:
         mock_confirm.return_value = True
         assert get_modify_resource_approval("provision", [])

--- a/tests/test_cli/test_ui_functions.py
+++ b/tests/test_cli/test_ui_functions.py
@@ -2,14 +2,14 @@
 
 from unittest import mock
 
-from matcha_ml.cli.ui.functions import is_approved
+from matcha_ml.cli.ui.functions import get_modify_resource_approval
 
 
-def test_is_approved():
+def test_get_modify_resource_approvals():
     """Test if is_approved behaves as expected based on user's input."""
     with mock.patch("typer.confirm") as mock_confirm:
         mock_confirm.return_value = True
-        assert is_approved("provision", [])
+        assert get_modify_resource_approval("provision", [])
 
         mock_confirm.return_value = False
-        assert not is_approved("provision", [])
+        assert not get_modify_resource_approval("provision", [])

--- a/tests/test_cli/test_ui_functions.py
+++ b/tests/test_cli/test_ui_functions.py
@@ -12,7 +12,7 @@ def test_user_approves():
         assert is_user_approved("provision", [])
 
 
-def test_user_does_approves():
+def test_user_does_not_approves():
     """Test if is_user_approved behaves as expected where user does not provide approval."""
     with mock.patch("typer.confirm") as mock_confirm:
         mock_confirm.return_value = False

--- a/tests/test_cli/test_ui_functions.py
+++ b/tests/test_cli/test_ui_functions.py
@@ -2,14 +2,18 @@
 
 from unittest import mock
 
-from matcha_ml.cli.ui.functions import get_modify_resource_approval
+from matcha_ml.cli.ui.user_approval_functions import is_user_approved
 
 
-def test_get_modify_resource_approvals():
-    """Test if get_modify_resource_approval behaves as expected based on user's input."""
+def test_user_approves():
+    """Test if is_user_approved behaves as expected where user provides approval."""
     with mock.patch("typer.confirm") as mock_confirm:
         mock_confirm.return_value = True
-        assert get_modify_resource_approval("provision", [])
+        assert is_user_approved("provision", [])
 
+
+def test_user_does_approves():
+    """Test if is_user_approved behaves as expected where user does not provide approval."""
+    with mock.patch("typer.confirm") as mock_confirm:
         mock_confirm.return_value = False
-        assert not get_modify_resource_approval("provision", [])
+        assert not is_user_approved("provision", [])

--- a/tests/test_runners/test_azure_runner.py
+++ b/tests/test_runners/test_azure_runner.py
@@ -162,18 +162,18 @@ def template_runner() -> AzureRunner:
     return AzureRunner()
 
 
-def test_is_approved(template_runner: AzureRunner):
-    """Test if is_approved behaves as expected based on user's input.
+# def test_is_approved(template_runner: AzureRunner):
+#     """Test if is_approved behaves as expected based on user's input.
 
-    Args:
-        template_runner (AzureRunner): a AzureRunner object instance
-    """
-    with mock.patch("typer.confirm") as mock_confirm:
-        mock_confirm.return_value = True
-        assert template_runner.is_approved("provision", [])
+#     Args:
+#         template_runner (AzureRunner): a AzureRunner object instance
+#     """
+#     with mock.patch("typer.confirm") as mock_confirm:
+#         mock_confirm.return_value = True
+#         assert template_runner.is_approved("provision", [])
 
-        mock_confirm.return_value = False
-        assert not template_runner.is_approved("provision", [])
+#         mock_confirm.return_value = False
+#         assert not template_runner.is_approved("provision", [])
 
 
 def test_write_outputs_state(

--- a/tests/test_runners/test_azure_runner.py
+++ b/tests/test_runners/test_azure_runner.py
@@ -162,20 +162,6 @@ def template_runner() -> AzureRunner:
     return AzureRunner()
 
 
-# def test_is_approved(template_runner: AzureRunner):
-#     """Test if is_approved behaves as expected based on user's input.
-
-#     Args:
-#         template_runner (AzureRunner): a AzureRunner object instance
-#     """
-#     with mock.patch("typer.confirm") as mock_confirm:
-#         mock_confirm.return_value = True
-#         assert template_runner.is_approved("provision", [])
-
-#         mock_confirm.return_value = False
-#         assert not template_runner.is_approved("provision", [])
-
-
 def test_write_outputs_state(
     template_runner: AzureRunner,
     terraform_test_config: TerraformConfig,


### PR DESCRIPTION
This pull request refactors the `is_approved` logic, which is currently a method of the `runners.azure_runner.AzureRunner` class, into a separate module within the `cli.ui` submodule.  The logic of the function is unchanged; imports and references have been updated to reflect the new location.

## Checklist

Please ensure you have done the following:

* [X] I have read the [CONTRIBUTING](https://github.com/fuzzylabs/matcha/blob/main/CONTRIBUTING.md) guide.
* [ ] I have updated the documentation if required.
* [X] I have added tests which cover my changes.

## Type of change

Tick all those that apply:

* [ ] Bug Fix (non-breaking change, fixing an issue)
* [ ] New feature (non-breaking change to add functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [X] Other (add details above)
