### PR TITLE
[RPD-254] no state file after destroying resources

### DIFF
--- a/src/matcha_ml/services/analytics_service.py
+++ b/src/matcha_ml/services/analytics_service.py
@@ -34,8 +34,7 @@ def execute_analytics_event(func: Callable, *args, **kwargs) -> Tuple[Optional[M
     Returns:
         The result of the call to func, the error code.
     """
-    error_code = None
-    result = None
+    error_code, result = None, None
     try:
         result = func(*args, **kwargs)
     except Exception as e:
@@ -69,11 +68,8 @@ def track(event_name: AnalyticsEvent) -> Callable[..., Any]:
                 Any: the result of the wrapped function.
             """
             global_params = GlobalParameters()
-            result = None
-            error_code = None
-            te = None
-            ts = None
-            if event_name.value not in [event.value for event in AnalyticsEvent]:
+            result, error_code, te, ts = None, None, None, None
+            if event_name.value not in {event.value for event in AnalyticsEvent}:
                 warn("Event not recognised by analytics service.")
 
             if not global_params.analytics_opt_out:


### PR DESCRIPTION
This PR patches over the issue of tracking destruction events leading to errors. 

This is done by having two conditionals which check the type of analytic event being tracked, and executing the call to the associated function in the appropriate place inside the track decorator. 

This is only a temporary fix and will be entirely removed by the imminent re-writing of the track decorator. This will remain a draft until I have successfully ran the entire pipeline without issue tomorrow.

## Checklist

Please ensure you have done the following:

* [x] I have read the [CONTRIBUTING](https://github.com/fuzzylabs/matcha/blob/main/CONTRIBUTING.md) guide.
* [ ] I have updated the documentation if required.
* [ ] I have added tests which cover my changes.

## Type of change

Tick all those that apply:

* [x] Bug Fix (non-breaking change, fixing an issue)
* [ ] New feature (non-breaking change to add functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Other (add details above)
