### PR TITLE
[RPD-256] Add connection string for experiment tracker storage account to state

### DIFF
--- a/src/matcha_ml/cli/ui/resource_message_builders.py
+++ b/src/matcha_ml/cli/ui/resource_message_builders.py
@@ -7,7 +7,12 @@ from rich.console import Console
 
 err_console = Console(stderr=True)
 
-SENSITIVE_OUTPUT = ["connection-string", "server-username", "server-password"]
+SENSITIVE_OUTPUT = [
+    "connection-string",
+    "server-username",
+    "server-password",
+    "azure-connection-string",
+]
 HIDDEN_STR = "********"
 
 

--- a/src/matcha_ml/infrastructure/resources/main.tf
+++ b/src/matcha_ml/infrastructure/resources/main.tf
@@ -55,7 +55,6 @@ module "mlflow" {
   storage_account_name      = module.storage.storage_account_name
   storage_container_name    = module.storage.storage_container_name
   artifact_azure_access_key = module.storage.primary_access_key
-
 }
 
 

--- a/src/matcha_ml/infrastructure/resources/output.tf
+++ b/src/matcha_ml/infrastructure/resources/output.tf
@@ -3,6 +3,12 @@ output "experiment_tracker_mlflow_tracking_url" {
   value       = module.mlflow.mlflow_tracking_url
 }
 
+output "experiment_tracker_mlflow_azure_connection_string"{
+  description = "The Azure connection string for the MLflow storage on Azure"
+  value       = module.storage.primary_connection_string
+  sensitive   = true
+}
+
 output "pipeline_zenml_storage_path" {
   description = "The Azure Blob Storage Container path for storing ZenML artifacts"
   value       = module.zenml_storage.zenml_blobstorage_container_path


### PR DESCRIPTION
This PR adds a new Terraform output variable under the `experiment-tracking` resource, specifically, the Azure connection string required for MLflow to access the storage bucket in which the experiment-tracking data and artifacts are held.

## Checklist

Please ensure you have done the following:

* [ ] I have read the [CONTRIBUTING](https://github.com/fuzzylabs/matcha/blob/main/CONTRIBUTING.md) guide.
* [ ] I have updated the documentation if required.
* [ ] I have added tests which cover my changes.

## Type of change

Tick all those that apply:

* [ ] Bug Fix (non-breaking change, fixing an issue)
* [ ] New feature (non-breaking change to add functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Other (add details above)
