### PR TITLE
[RPD-255] improve docstrings in core module

### DIFF
--- a/src/matcha_ml/core/core.py
+++ b/src/matcha_ml/core/core.py
@@ -154,7 +154,7 @@ def provision(
 ) -> MatchaState:
     """Provision cloud resources using existing Matcha Terraform templates.
 
-    Provision cloud resources in the location provided. Provide a prefix for the Azure group's  name and a password for
+    Provision cloud resources in the location provided. Provide a prefix for the Azure group's name and a password for
     the provisioned server. To show more output than the default, set verbose to True.
 
     Examples:
@@ -167,7 +167,7 @@ def provision(
     Args:
         location (str): Azure location in which all resources will be provisioned.
         prefix (str): Prefix used for all resources.
-        password (str): Password for ZenServer.
+        password (str): Password for the deployment server.
         verbose (bool optional): additional output is show when True. Defaults to False.
 
     Returns:

--- a/src/matcha_ml/core/core.py
+++ b/src/matcha_ml/core/core.py
@@ -105,7 +105,8 @@ def destroy() -> None:
     """Destroy the provisioned cloud resources.
 
     Decommission the cloud infrastructure built by matcha when provision has been called either historically or during
-    this session.
+    this session. After calling destroy, the resources provisioned by matcha should no longer be active on your
+    chosen provider's UI.
 
     Raises:
         Matcha Error: where no state has been provisioned.

--- a/src/matcha_ml/core/core.py
+++ b/src/matcha_ml/core/core.py
@@ -20,9 +20,20 @@ def get(
     resource_name: Optional[str],
     property_name: Optional[str],
 ) -> MatchaState:
-    """Return the information of the provisioned resource based on the resource name specified.
+    """Return information regarding a previously provisioned resource based on the resource and property names provided.
 
-    Return all resources if no resource name is specified.
+    The information is returned in the form of a `MatchaState` object containing various `MatchaStateComponent` objects.
+    The `MatchaStateComponent` objects in turn hold `MatchaResource` and `MatchaResourceProperty` components.
+    If no resource name is provided, all resources are returned.
+
+    Examples:
+        >>> get("cloud", "resource-group-name")
+        MatchaState(components=[MatchaStateComponent(resource=MatchaResource(name='cloud'),
+        properties=[MatchaResourceProperty(name='resource-group-name', value='test_resources')])])
+
+        >>> get("experiment-tracker", "flavor")
+        MatchaState(components=[MatchaStateComponent(resource=MatchaResource(name='experiment-tracker'),
+        properties=[MatchaResourceProperty(name='flavor', value='mlflow')])])
 
     Args:
         resource_name (Optional[str]): name of the resource to get information for.
@@ -91,7 +102,7 @@ def get(
 
 @track(event_name=AnalyticsEvent.DESTROY)
 def destroy() -> None:
-    """Destroys provisioned resources in the cloud.
+    """Destroy the provisioned cloud resources.
 
     Raises:
         Matcha Error: where no state has been provisioned.
@@ -120,7 +131,7 @@ def analytics_opt_in() -> None:
 
 
 def remove_state_lock() -> None:
-    """Unlock remote state."""
+    """Unlock the remote state."""
     remote_state = RemoteStateManager()
     remote_state.unlock()
 
@@ -132,7 +143,17 @@ def provision(
     password: str,
     verbose: Optional[bool] = False,
 ) -> MatchaState:
-    """Provision cloud resources using templates.
+    """Provision cloud resources using existing matcha templates.
+
+    Provision cloud resources in the location provided. Provide a prefix to differentiate the provisioned resources from
+    other, existing resources, and provide a password. To show more output than the default, set verbose to True.
+
+    Examples:
+        >>> provision(location="ukwest", prefix="myexample", password="example_password", verbose=False)
+        MatchaState(components=[MatchaStateComponent(resource=MatchaResource(name='cloud'),
+            properties=[MatchaResourceProperty(name='location', value='ukwest'),
+            MatchaResourceProperty(name='prefix', value='test')])])
+
 
     Args:
         location (str): Azure location in which all resources will be provisioned.

--- a/src/matcha_ml/core/core.py
+++ b/src/matcha_ml/core/core.py
@@ -125,12 +125,19 @@ def destroy() -> None:
 
 
 def analytics_opt_out() -> None:
-    """Disable the collection of anonymous usage data."""
+    """Disable the collection of anonymous usage data.
+
+    More information regarding why we collect usage data, and how it is used, can be found
+    [here](https://mymatcha.ai/privacy/).
+    """
     GlobalParameters().analytics_opt_out = True
 
 
 def analytics_opt_in() -> None:
-    """Enable the collection of anonymous usage data (enabled by default)."""
+    """Enable the collection of anonymous usage data (enabled by default).
+
+    More information regarding why we collect usage data, and how it is used, can be found
+    [here](https://mymatcha.ai/privacy/)."""
     GlobalParameters().analytics_opt_out = False
 
 

--- a/src/matcha_ml/core/core.py
+++ b/src/matcha_ml/core/core.py
@@ -104,6 +104,9 @@ def get(
 def destroy() -> None:
     """Destroy the provisioned cloud resources.
 
+    Decommission the cloud infrastructure built by matcha when provision has been called either historically or during
+    this session.
+
     Raises:
         Matcha Error: where no state has been provisioned.
     """

--- a/src/matcha_ml/core/core.py
+++ b/src/matcha_ml/core/core.py
@@ -1,4 +1,4 @@
-"""The core functions for matcha."""
+"""The core functionality for Matcha API."""
 import os
 from typing import Optional
 
@@ -104,7 +104,7 @@ def get(
 def destroy() -> None:
     """Destroy the provisioned cloud resources.
 
-    Decommission the cloud infrastructure built by matcha when provision has been called either historically or during
+    Decommission the cloud infrastructure built by Matcha when provision has been called either historically or during
     this session. After calling destroy, the resources provisioned by matcha should no longer be active on your
     chosen provider's UI.
 
@@ -135,7 +135,12 @@ def analytics_opt_in() -> None:
 
 
 def remove_state_lock() -> None:
-    """Unlock the remote state."""
+    """Unlock the remote state.
+
+    Note:
+        The remote state is synced to a state file kept locally. The state will be locked when in use, and removing the
+        state lock and making changes could result in a state file not consistent with what Matcha expects.
+    """
     remote_state = RemoteStateManager()
     remote_state.unlock()
 
@@ -147,10 +152,10 @@ def provision(
     password: str,
     verbose: Optional[bool] = False,
 ) -> MatchaState:
-    """Provision cloud resources using existing matcha templates.
+    """Provision cloud resources using existing Matcha Terraform templates.
 
-    Provision cloud resources in the location provided. Provide a prefix to differentiate the provisioned resources from
-    other, existing resources, and provide a password. To show more output than the default, set verbose to True.
+    Provision cloud resources in the location provided. Provide a prefix for the Azure group's  name and a password for
+    the provisioned server. To show more output than the default, set verbose to True.
 
     Examples:
         >>> provision(location="ukwest", prefix="myexample", password="example_password", verbose=False)


### PR DESCRIPTION
This is a very small PR which extends the `destroy()`, `get()` and `provision()` docstrings slightly, such that the API docs are more easily followed.

## Checklist
Please ensure you have done the following:
* [x] I have read the [CONTRIBUTING](https://github.com/fuzzylabs/matcha/blob/main/CONTRIBUTING.md) guide.
* [x] I have updated the documentation if required.
* [ ] I have added tests which cover my changes.
## Type of change
Tick all those that apply:
Docs improvement
* [ ] Bug Fix (non-breaking change, fixing an issue)
* [ ] New feature (non-breaking change to add functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Other (add details above)