### PR TITLE
[BUG] [RPD-258] Instantiate MatchStateService after downloading the matcha state from the remote storage

### DIFF
--- a/src/matcha_ml/core/core.py
+++ b/src/matcha_ml/core/core.py
@@ -42,7 +42,6 @@ def get(
     if property_name:
         property_name = property_name.lower()
 
-    matcha_state_service = MatchaStateService()
     remote_state = RemoteStateManager()
 
     if not remote_state.is_state_provisioned():
@@ -50,12 +49,11 @@ def get(
             "Error - matcha state has not been initialized, nothing to get."
         )
 
-    if not matcha_state_service.state_exists():
+    if not MatchaStateService.state_exists():
         # if the state file doesn't exist, then download it from the remote
         remote_state.download(os.getcwd())
 
-        # reinitialise to create the necessary variables
-        matcha_state_service = MatchaStateService()
+    matcha_state_service = MatchaStateService()
 
     with remote_state.use_lock():
         local_hash = matcha_state_service.get_hash_local_state()


### PR DESCRIPTION
Currently, when a user does not have a `.matcha` file locally that is not up to date with the remote state the user will encounter an error when trying to run `matcha get` to download/sync the state files.

This PR adds a test describing this bug and fixes it by calling the class method to check if the state file exists before instantiating the object `MatchaStateService` and then instantiating after the check and download remote state has completed.

## Checklist

Please ensure you have done the following:

* [x] I have read the [CONTRIBUTING](https://github.com/fuzzylabs/matcha/blob/main/CONTRIBUTING.md) guide.
* [ ] I have updated the documentation if required.
* [x] I have added tests which cover my changes.

## Type of change

Tick all those that apply:

* [x] Bug Fix (non-breaking change, fixing an issue)
* [ ] New feature (non-breaking change to add functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Other (add details above)
