### PR TITLE
[RPD-261] [BUG] destroy leads to missing matcha config file error

### DIFF
--- a/src/matcha_ml/core/core.py
+++ b/src/matcha_ml/core/core.py
@@ -117,7 +117,9 @@ def destroy() -> None:
         )
 
     template_runner = AzureRunner()
-    with remote_state_manager.use_lock(), remote_state_manager.use_remote_state():
+    with remote_state_manager.use_lock(
+        destroy=True
+    ), remote_state_manager.use_remote_state(destroy=True):
         template_runner.deprovision()
         remote_state_manager.deprovision_remote_state()
 

--- a/src/matcha_ml/state/remote_state_manager.py
+++ b/src/matcha_ml/state/remote_state_manager.py
@@ -292,7 +292,7 @@ class RemoteStateManager:
         )
 
     @contextlib.contextmanager
-    def use_remote_state(self) -> Iterator[None]:
+    def use_remote_state(self, destroy: bool = False) -> Iterator[None]:
         """Context manager to use remote state.
 
         Downloads the state before executing the code.
@@ -302,7 +302,8 @@ class RemoteStateManager:
 
         yield None
 
-        self.upload(os.path.join(".matcha", "infrastructure"))
+        if not destroy:
+            self.upload(os.path.join(".matcha", "infrastructure"))
 
     def lock(self) -> None:
         """Lock remote state.
@@ -335,10 +336,11 @@ class RemoteStateManager:
             )
 
     @contextlib.contextmanager
-    def use_lock(self) -> Iterator[None]:
+    def use_lock(self, destroy: bool = False) -> Iterator[None]:
         """Context manager to lock state."""
         self.lock()
         try:
             yield
         finally:
-            self.unlock()
+            if not destroy:
+                self.unlock()

--- a/src/matcha_ml/state/remote_state_manager.py
+++ b/src/matcha_ml/state/remote_state_manager.py
@@ -297,6 +297,9 @@ class RemoteStateManager:
 
         Downloads the state before executing the code.
         Upload the state when context is finished.
+
+        Args:
+            destroy (bool): Flag for whether the command being run is 'destroy' or not.
         """
         self.download(os.getcwd())
 
@@ -337,7 +340,11 @@ class RemoteStateManager:
 
     @contextlib.contextmanager
     def use_lock(self, destroy: bool = False) -> Iterator[None]:
-        """Context manager to lock state."""
+        """Context manager to lock state.
+
+        Args:
+            destroy (bool): Flag for whether the command being run is 'destroy' or not.
+        """
         self.lock()
         try:
             yield


### PR DESCRIPTION
The error is due to the context managers `use_remote_state` and `use_lock`. These both call functions dependent on the Azure bucket existing: `unlock` and `upload`. To fix this we updated context managers to avoid erroring on destroy after the remote bucket is removed by introducing a `destroy` variable which prevents these two functions from being run on a `destroy` command.

## Checklist

Please ensure you have done the following:

* [x] I have read the [CONTRIBUTING](https://github.com/fuzzylabs/matcha/blob/main/CONTRIBUTING.md) guide.
* [ ] I have updated the documentation if required.
* [ ] I have added tests which cover my changes.

## Type of change

Tick all those that apply:

* [x] Bug Fix (non-breaking change, fixing an issue)
* [ ] New feature (non-breaking change to add functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Other (add details above)
