### PR TITLE
[RPD-271] [BUG] Fix orphaned `NetworkWatcherRG` resource group

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -233,4 +233,6 @@ The final thing you'll want to do is decommission the infrastructure that Matcha
 matcha destroy
 ```
 
-> Note that this command is irreversible will remove all the resources deployed by `matcha provision` including the resource group, so make sure you save any data you wish to keep before running this command.
+> Note: that this command is irreversible will remove all the resources deployed by `matcha provision` including the resource group, so make sure you save any data you wish to keep before running this command.
+> 
+> You may also notice that an additional resource has appeared in Azure called 'NetworkWatcherRG' (if it wasn't already there). This is a resource that is automatically provisioned by Azure in each region when there is in-coming traffic to a provisioned resource and isn't controlled by Matcha. More information can be found [here](https://learn.microsoft.com/en-us/azure/network-watcher/network-watcher-monitoring-overview) on how to manage or remove this resource.

--- a/docs/inside-matcha.md
+++ b/docs/inside-matcha.md
@@ -33,3 +33,5 @@ The user can use `get` to request information on specific resources or propertie
 ## `destroy`
 
 Once the user has finished with their provisioned environment, `destroy` enables them to tear down the resources. It works by calling the `destroy` Terraform command via the `python-terraform` library, which interacts with the configured Terraform files in the `.matcha/` directory.
+
+> You may also notice that an additional resource has appeared in Azure called 'NetworkWatcherRG' (if it wasn't already there). This is a resource that is automatically provisioned by Azure in each region when there is in-coming traffic to a provisioned resource and isn't controlled by Matcha. More information can be found [here](https://learn.microsoft.com/en-us/azure/network-watcher/network-watcher-monitoring-overview) on how to manage or remove this resource.


### PR DESCRIPTION
This was reported as a bug, however, it's actually a feature. The `NetworkWatcherRG` is a resource group that is automatically provisioned by Azure when:

1. A resource has in-coming traffic; AND,
2. When a `NetworkWatcherRG` doesn't already exist in the region for the subscription.

This sits at a higher level than Matcha, and isn't controlled by the tool. 

This PR adds clarifying statements to the documentation, pointing to information on Azure.

## Checklist

Please ensure you have done the following:

* [x] I have read the [CONTRIBUTING](https://github.com/fuzzylabs/matcha/blob/main/CONTRIBUTING.md) guide.
* [x] I have updated the documentation if required.
* [ ] I have added tests which cover my changes.

## Type of change

Tick all those that apply:

* [x] Bug Fix (non-breaking change, fixing an issue)
* [ ] New feature (non-breaking change to add functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Other (add details above)
