### PR TITLE
[RPD-276] [BUG] Turning analytics `on` causes hanging in the analytics service

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -98,7 +98,7 @@ def mocked_segment_track_decorator():
         MagicMock: Mocked segment track function.
     """
     with patch(
-        "matcha_ml.services.analytics_service.analytics.track"
+        "matcha_ml.services.analytics_service.analytics.Client.track"
     ) as track_analytics:
         track_analytics.return_value = None
 


### PR DESCRIPTION
This bug was caused by local networks not allowing access to the Segment server. This bug can be recreated by adding `127.0.0.1    api.segment.io` to `/etc/hosts`. And running any `matcha` command that has a `track` decorator.

To fix this we set the Segment max tries to 1 and suppress Segment logging output.

This also fixes issue RPD-262

## Checklist

Please ensure you have done the following:

* [x] I have read the [CONTRIBUTING](https://github.com/fuzzylabs/matcha/blob/main/CONTRIBUTING.md) guide.
* [x] I have updated the documentation if required.
* [ ] I have added tests which cover my changes.

## Type of change

Tick all those that apply:

* [x] Bug Fix (non-breaking change, fixing an issue)
* [ ] New feature (non-breaking change to add functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Other (add details above)
