### PR TITLE
[RPD-279] [BUG] Automatically deal with stale states 

### DIFF
--- a/src/matcha_ml/infrastructure/remote_state_storage/output.tf
+++ b/src/matcha_ml/infrastructure/remote_state_storage/output.tf
@@ -22,3 +22,8 @@ output "cloud_azure_location"{
   description = "The Azure location in which the resources are provisioned" 
   value = var.location
 }
+
+output "cloud_azure_resource_group_name" {
+  description = "Name of the Azure resource group"
+  value = module.resource_group.name
+}

--- a/src/matcha_ml/state/matcha_state.py
+++ b/src/matcha_ml/state/matcha_state.py
@@ -140,7 +140,7 @@ class MatchaStateService:
 
         Raises:
             MatchaError: if the state file does not exist.
-            MatchaError: if MatchaStateService is initialize with both 'matcha_state' and 'terraform_output' arguments.
+            MatchaError: if MatchaStateService is initialized with both 'matcha_state' and 'terraform_output' arguments.
         """
         if matcha_state is not None and terraform_output is not None:
             raise MatchaError(

--- a/src/matcha_ml/templates/azure_template.py
+++ b/src/matcha_ml/templates/azure_template.py
@@ -53,6 +53,7 @@ class AzureTemplate(BaseTemplate):
         # Add matcha.state file one directory above the template
         config_dict = vars(config)
         _ = config_dict.pop("password", None)
+        config_dict["resource-group-name"] = f"{config_dict['prefix']}-resources"
         initial_state_file_dict = {"cloud": config_dict}
         matcha_state = MatchaState.from_dict(initial_state_file_dict)
         MatchaStateService(matcha_state=matcha_state)


### PR DESCRIPTION
This bug is recreated by allowing the state storage to be provisioned and stopping the program before reaching the AKS and other resources provisioning. This meant that the `matcha.state` file looks similar to:
```
{
    "cloud": {
        "prefix": "test",
        "location": "uksouth",
    }
}
```
Which does not include `resource-group-name` hence when we try to access this value to check if the matcha state is stale
we get an error that the value does not exist.
Instead the `matcha.state` file needs to be:
```
{
    "cloud": {
        "prefix": "test",
        "location": "uksouth",
        "resource-group-name": "test-resources"
    }
}
```
After the resource group and state storage is provisioned.

This bug can happen if there is something wrong with the `resources` Terraform and the Terraform init/apply fails causing matcha to halt halfway through provisioning.


To fix this we add the resource group name to `matcha.state` file after provisioning the remote state rg and storage.

## Checklist

Please ensure you have done the following:

* [x] I have read the [CONTRIBUTING](https://github.com/fuzzylabs/matcha/blob/main/CONTRIBUTING.md) guide.
* [x] I have updated the documentation if required.
* [ ] I have added tests which cover my changes.

## Type of change

Tick all those that apply:

* [x] Bug Fix (non-breaking change, fixing an issue)
* [ ] New feature (non-breaking change to add functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Other (add details above)
