### PR TITLE
[RPD-205] add data versioning terraform files to infrastructure

### DIFF
--- a/src/matcha_ml/infrastructure/resources/data_version_control_storage/README.md
+++ b/src/matcha_ml/infrastructure/resources/data_version_control_storage/README.md
@@ -1,0 +1,44 @@
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | 3.48.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.48.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [azurerm_storage_account.storageaccount](https://registry.terraform.io/providers/hashicorp/azurerm/3.48.0/docs/resources/storage_account) | resource |
+| [azurerm_storage_container.storagecontainer](https://registry.terraform.io/providers/hashicorp/azurerm/3.48.0/docs/resources/storage_container) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_location"></a> [location](#input\_location) | The Azure Region in which this resources should be created. | `string` | n/a | yes |
+| <a name="input_prefix"></a> [prefix](#input\_prefix) | The prefix which should be used for naming storage account ({prefix}storageacc) and container ({prefix}storagecontainer) | `string` | n/a | yes |
+| <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | The resource group name which is used to create the resource group | `string` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_blobstorage_container_path"></a> [blobstorage\_container\_path](#output\_blobstorage\_container\_path) | The Azure Blob Storage Container path for storing your artifacts |
+| <a name="output_primary_access_key"></a> [primary\_access\_key](#output\_primary\_access\_key) | Azure Storage Account - Primary access key |
+| <a name="output_primary_blob_connection_string"></a> [primary\_blob\_connection\_string](#output\_primary\_blob\_connection\_string) | Azure Storage Account - Primary Blob service connection string |
+| <a name="output_primary_connection_string"></a> [primary\_connection\_string](#output\_primary\_connection\_string) | Azure Storage Account - Primary connection string |
+| <a name="output_secondary_access_key"></a> [secondary\_access\_key](#output\_secondary\_access\_key) | Azure Storage Account - Secondary access key |
+| <a name="output_secondary_blob_connection_string"></a> [secondary\_blob\_connection\_string](#output\_secondary\_blob\_connection\_string) | Azure Storage Account - Secondary Blob service connection string |
+| <a name="output_secondary_connection_string"></a> [secondary\_connection\_string](#output\_secondary\_connection\_string) | Azure Storage Account - Secondary connection string |
+| <a name="output_storage_account_name"></a> [storage\_account\_name](#output\_storage\_account\_name) | The name of the Azure Storage Account. |
+| <a name="output_storage_container_name"></a> [storage\_container\_name](#output\_storage\_container\_name) | The name of the Azure Storage Container. |

--- a/src/matcha_ml/infrastructure/resources/data_version_control_storage/main.tf
+++ b/src/matcha_ml/infrastructure/resources/data_version_control_storage/main.tf
@@ -1,0 +1,22 @@
+# Reference: https://github.com/hashicorp/terraform-provider-azurerm/tree/main/examples/storage/storage-container
+
+# create a storage account
+resource "azurerm_storage_account" "storageaccount" {
+  name                = "${var.prefix}dvcacc"
+  resource_group_name = var.resource_group_name
+  location            = var.location
+
+  account_tier                    = "Standard"
+  account_kind                    = "StorageV2"
+  account_replication_type        = "LRS"
+  enable_https_traffic_only       = true
+  access_tier                     = "Hot"
+  allow_nested_items_to_be_public = true
+}
+
+# create a storage container inside created storage account
+resource "azurerm_storage_container" "storagecontainer" {
+  name                  = "${var.prefix}dvcstore"
+  storage_account_name  = azurerm_storage_account.storageaccount.name
+  container_access_type = "container"
+}

--- a/src/matcha_ml/infrastructure/resources/data_version_control_storage/output.tf
+++ b/src/matcha_ml/infrastructure/resources/data_version_control_storage/output.tf
@@ -1,0 +1,50 @@
+output "storage_container_name" {
+  description = "The name of the Azure Storage Container."
+  value = azurerm_storage_container.storagecontainer.name
+}
+
+output "blobstorage_container_path" {
+  description = "The Azure Blob Storage Container path for storing your artifacts"
+  value       = "az://${azurerm_storage_container.storagecontainer.name}"
+}
+
+output "storage_account_name" {
+  description = "The name of the Azure Storage Account."
+  value = azurerm_storage_account.storageaccount.name
+}
+
+output "primary_access_key" {
+  description = "Azure Storage Account - Primary access key"
+  value       = azurerm_storage_account.storageaccount.primary_access_key
+  sensitive   = true
+}
+
+output "secondary_access_key" {
+  description = "Azure Storage Account - Secondary access key"
+  value       = azurerm_storage_account.storageaccount.secondary_access_key
+  sensitive   = true
+}
+
+output "primary_connection_string" {
+  description = "Azure Storage Account - Primary connection string"
+  value       = azurerm_storage_account.storageaccount.primary_connection_string
+  sensitive   = true
+}
+
+output "secondary_connection_string" {
+  description = "Azure Storage Account - Secondary connection string"
+  value       = azurerm_storage_account.storageaccount.secondary_connection_string
+  sensitive   = true
+}
+
+output "primary_blob_connection_string" {
+  description = "Azure Storage Account - Primary Blob service connection string"
+  value       = azurerm_storage_account.storageaccount.primary_blob_connection_string
+  sensitive   = true
+}
+
+output "secondary_blob_connection_string" {
+  description = "Azure Storage Account - Secondary Blob service connection string"
+  value       = azurerm_storage_account.storageaccount.secondary_blob_connection_string
+  sensitive   = true
+}

--- a/src/matcha_ml/infrastructure/resources/data_version_control_storage/output.tf
+++ b/src/matcha_ml/infrastructure/resources/data_version_control_storage/output.tf
@@ -3,48 +3,13 @@ output "storage_container_name" {
   value = azurerm_storage_container.storagecontainer.name
 }
 
-output "blobstorage_container_path" {
-  description = "The Azure Blob Storage Container path for storing your artifacts"
-  value       = "az://${azurerm_storage_container.storagecontainer.name}"
-}
-
 output "storage_account_name" {
   description = "The name of the Azure Storage Account."
-  value = azurerm_storage_account.storageaccount.name
-}
-
-output "primary_access_key" {
-  description = "Azure Storage Account - Primary access key"
-  value       = azurerm_storage_account.storageaccount.primary_access_key
-  sensitive   = true
-}
-
-output "secondary_access_key" {
-  description = "Azure Storage Account - Secondary access key"
-  value       = azurerm_storage_account.storageaccount.secondary_access_key
-  sensitive   = true
+  value       = azurerm_storage_account.storageaccount.name
 }
 
 output "primary_connection_string" {
   description = "Azure Storage Account - Primary connection string"
   value       = azurerm_storage_account.storageaccount.primary_connection_string
-  sensitive   = true
-}
-
-output "secondary_connection_string" {
-  description = "Azure Storage Account - Secondary connection string"
-  value       = azurerm_storage_account.storageaccount.secondary_connection_string
-  sensitive   = true
-}
-
-output "primary_blob_connection_string" {
-  description = "Azure Storage Account - Primary Blob service connection string"
-  value       = azurerm_storage_account.storageaccount.primary_blob_connection_string
-  sensitive   = true
-}
-
-output "secondary_blob_connection_string" {
-  description = "Azure Storage Account - Secondary Blob service connection string"
-  value       = azurerm_storage_account.storageaccount.secondary_blob_connection_string
   sensitive   = true
 }

--- a/src/matcha_ml/infrastructure/resources/data_version_control_storage/providers.tf
+++ b/src/matcha_ml/infrastructure/resources/data_version_control_storage/providers.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "3.48.0"
+    }
+  }
+}

--- a/src/matcha_ml/infrastructure/resources/data_version_control_storage/variables.tf
+++ b/src/matcha_ml/infrastructure/resources/data_version_control_storage/variables.tf
@@ -1,0 +1,14 @@
+variable "resource_group_name" {
+  description = "The resource group name which is used to create the resource group"
+  type        = string
+}
+
+variable "prefix" {
+  description = "The prefix which should be used for naming storage account ({prefix}dvcacc) and container ({prefix}dvcstore)"
+  type        = string
+}
+
+variable "location" {
+  description = "The Azure Region in which this resources should be created."
+  type        = string
+}

--- a/src/matcha_ml/infrastructure/resources/main.tf
+++ b/src/matcha_ml/infrastructure/resources/main.tf
@@ -29,13 +29,6 @@ module "zenml_storage" {
   aks_principal_id    = module.aks.aks_principal_id
 }
 
-module "data_version_control_storage" {
-  source = "./data_version_control_storage"
-
-  prefix              = var.prefix
-  resource_group_name = module.resource_group.name
-  location            = var.location
-}
 
 module "aks" {
   source = "./aks"

--- a/src/matcha_ml/infrastructure/resources/main.tf
+++ b/src/matcha_ml/infrastructure/resources/main.tf
@@ -29,6 +29,14 @@ module "zenml_storage" {
   aks_principal_id    = module.aks.aks_principal_id
 }
 
+module "data_version_control_storage" {
+  source = "./data_version_control_storage"
+
+  prefix              = var.prefix
+  resource_group_name = module.resource_group.name
+  location            = var.location
+}
+
 module "aks" {
   source = "./aks"
 

--- a/src/matcha_ml/infrastructure/resources/output.tf
+++ b/src/matcha_ml/infrastructure/resources/output.tf
@@ -14,10 +14,6 @@ output "pipeline_zenml_storage_path" {
   value       = module.zenml_storage.zenml_blobstorage_container_path
 }
 
-output "data_version_control_storage_path" {
-  description = "The Azure Blob Storage Container path for data version control"
-  value = module.data_version_control_storage.blobstorage_container_path
-}
 
 output "pipeline_zenml_connection_string" {
   description = "The primary connection string for the ZenML Azure Storage Account"

--- a/src/matcha_ml/infrastructure/resources/output.tf
+++ b/src/matcha_ml/infrastructure/resources/output.tf
@@ -14,6 +14,11 @@ output "pipeline_zenml_storage_path" {
   value       = module.zenml_storage.zenml_blobstorage_container_path
 }
 
+output "data_version_control_storage_path" {
+  description = "The Azure Blob Storage Container path for data version control"
+  value = module.data_version_control_storage.blobstorage_container_path
+}
+
 output "pipeline_zenml_connection_string" {
   description = "The primary connection string for the ZenML Azure Storage Account"
   value       = module.zenml_storage.zenml_primary_connection_string


### PR DESCRIPTION
This PR adds the terraform files to the infrastructure directory for creating resources for storing and versioning data in future.

Add a data_version_control_storage/ directory to the infrastructure/ folder. Create an azurerm_storage_account resource and an azurerm_storage_container resource:

```
resource "azurerm_storage_account" "storageaccount" {
  name                = "${var.prefix}dvcacc"
  resource_group_name = var.resource_group_name
  location            = var.location

  account_tier                    = "Standard"
  account_kind                    = "StorageV2"
  account_replication_type        = "LRS"
  enable_https_traffic_only       = true
  access_tier                     = "Hot"
  allow_nested_items_to_be_public = true
}

resource "azurerm_storage_container" "storagecontainer" {
  name                  = "${var.prefix}dvcstore"
  storage_account_name  = azurerm_storage_account.storageaccount.name
  container_access_type = "container"
}
```

Outputs should be the container path, account name, access keys and connection strings. As per other resources provisioned by matcha, the variables should be the resource group name, prefix and location. 


Modules and outputs are not added to the `main.tf` and` output.tf` files in the main `resources/` directory to avoid throwing errors while the other functionality is implemented. 

## Checklist

Please ensure you have done the following:

* [ ] I have read the [CONTRIBUTING](https://github.com/fuzzylabs/matcha/blob/main/CONTRIBUTING.md) guide.
* [ ] I have updated the documentation if required.
* [ ] I have added tests which cover my changes.

## Type of change

Tick all those that apply:

* [ ] Bug Fix (non-breaking change, fixing an issue)
* [x] New feature (non-breaking change to add functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Other (add details above)
