### PR TITLE
RPD-280 remove RESOURCE_NAMES from azure_runner

### DIFF
--- a/src/matcha_ml/runners/azure_runner.py
+++ b/src/matcha_ml/runners/azure_runner.py
@@ -16,15 +16,6 @@ from matcha_ml.cli.ui.status_message_builders import (
 from matcha_ml.runners.base_runner import BaseRunner
 from matcha_ml.state.matcha_state import MatchaState, MatchaStateService
 
-RESOURCE_NAMES = [
-    "experiment_tracker",
-    "pipeline",
-    "orchestrator",
-    "cloud",
-    "container_registry",
-    "model_deployer",
-]
-
 
 class AzureRunner(BaseRunner):
     """A Runner class provides methods that interface with the Terraform service to facilitate the provisioning and deprovisioning of resources."""


### PR DESCRIPTION
RESOURCE_NAMES variable not used in azure_runner.py so has been removed. No need to move to constants.py.

## Checklist

Please ensure you have done the following:

* [ ] I have read the [CONTRIBUTING](https://github.com/fuzzylabs/matcha/blob/main/CONTRIBUTING.md) guide.
* [ ] I have updated the documentation if required.
* [ ] I have added tests which cover my changes.

## Type of change

Tick all those that apply:

* [x] Bug Fix (non-breaking change, fixing an issue)
* [ ] New feature (non-breaking change to add functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Other (add details above)
