### PR TITLE
[RPD-274] [BUG] Fix inaccurate provisioning messages

### DIFF
--- a/src/matcha_ml/runners/azure_runner.py
+++ b/src/matcha_ml/runners/azure_runner.py
@@ -57,7 +57,7 @@ class AzureRunner(BaseRunner):
         self._validate_terraform_config()
         self._validate_kubeconfig(base_path=".kube/config")
         self._initialize_terraform(msg="Matcha")
-        self._apply_terraform()
+        self._apply_terraform(msg="Matcha")
         tf_output = self.tfs.terraform_client.output()
         matcha_state_service = MatchaStateService(terraform_output=tf_output)
         self._show_terraform_outputs(matcha_state_service._state)

--- a/src/matcha_ml/runners/base_runner.py
+++ b/src/matcha_ml/runners/base_runner.py
@@ -131,8 +131,11 @@ class BaseRunner:
             )
             raise typer.Exit()
 
-    def _apply_terraform(self) -> None:
+    def _apply_terraform(self, msg: str = "") -> None:
         """Run terraform apply to create resources on cloud.
+
+        Args:
+            msg (str) : Message to display. Default is empty string.
 
         Raises:
             MatchaTerraformError: if 'terraform apply' failed.
@@ -149,7 +152,7 @@ class BaseRunner:
                 raise MatchaTerraformError(tf_error=tf_result.std_err)
         print_status(
             build_substep_success_status(
-                f"{Emojis.CHECKMARK.value} Matcha resources have been provisioned!\n"
+                f"{Emojis.CHECKMARK.value} {msg} resources have been provisioned!\n"
             )
         )
 

--- a/src/matcha_ml/runners/base_runner.py
+++ b/src/matcha_ml/runners/base_runner.py
@@ -131,11 +131,11 @@ class BaseRunner:
             )
             raise typer.Exit()
 
-    def _apply_terraform(self, msg: str = "") -> None:
+    def _apply_terraform(self, msg: str) -> None:
         """Run terraform apply to create resources on cloud.
 
         Args:
-            msg (str) : Message to display. Default is empty string.
+            msg (str) : Name of the type of resource (e.g. "Remote State" or "Matcha").
 
         Raises:
             MatchaTerraformError: if 'terraform apply' failed.

--- a/src/matcha_ml/runners/base_runner.py
+++ b/src/matcha_ml/runners/base_runner.py
@@ -131,7 +131,7 @@ class BaseRunner:
             )
             raise typer.Exit()
 
-    def _apply_terraform(self, msg: str) -> None:
+    def _apply_terraform(self, msg: str = "") -> None:
         """Run terraform apply to create resources on cloud.
 
         Args:
@@ -150,11 +150,19 @@ class BaseRunner:
 
             if tf_result.return_code != 0:
                 raise MatchaTerraformError(tf_error=tf_result.std_err)
-        print_status(
-            build_substep_success_status(
-                f"{Emojis.CHECKMARK.value} {msg} resources have been provisioned!\n"
+
+        if msg:
+            print_status(
+                build_substep_success_status(
+                    f"{Emojis.CHECKMARK.value} {msg} resources have been provisioned!\n"
+                )
             )
-        )
+        else:
+            print_status(
+                build_substep_success_status(
+                    f"{Emojis.CHECKMARK.value} Resources have been provisioned!\n"
+                )
+            )
 
     def _destroy_terraform(self, msg: str = "") -> None:
         """Destroy the provisioned resources.

--- a/src/matcha_ml/runners/remote_state_runner.py
+++ b/src/matcha_ml/runners/remote_state_runner.py
@@ -63,7 +63,7 @@ class RemoteStateRunner(BaseRunner):
         self._validate_terraform_config()
         self._validate_kubeconfig(base_path=".kube/config")
         self._initialize_terraform(msg="Remote State")
-        self._apply_terraform()
+        self._apply_terraform(msg="Remote State")
         return self._get_terraform_output()
 
     def deprovision(self) -> None:

--- a/tests/test_runners/test_base_runner.py
+++ b/tests/test_runners/test_base_runner.py
@@ -131,7 +131,7 @@ def test_apply_terraform(capsys: SysCapture):
     )
 
     with pytest.raises(MatchaTerraformError) as exc_info:
-        template_runner._apply_terraform()
+        template_runner._apply_terraform("Matcha")
         assert (
             str(exc_info.value)
             == "Terraform failed because of the following error: 'Apply failed'."

--- a/tests/test_runners/test_base_runner.py
+++ b/tests/test_runners/test_base_runner.py
@@ -131,7 +131,7 @@ def test_apply_terraform(capsys: SysCapture):
     )
 
     with pytest.raises(MatchaTerraformError) as exc_info:
-        template_runner._apply_terraform("Matcha")
+        template_runner._apply_terraform()
         assert (
             str(exc_info.value)
             == "Terraform failed because of the following error: 'Apply failed'."

--- a/tests/test_runners/test_base_runner.py
+++ b/tests/test_runners/test_base_runner.py
@@ -119,9 +119,9 @@ def test_apply_terraform(capsys: SysCapture):
     """
     template_runner = BaseRunner()
     template_runner.tfs.apply = MagicMock(return_value=TerraformResult(0, "", ""))
-    expected = "Matcha resources have been provisioned!"
+    expected = "Remote State resources have been provisioned!"
 
-    template_runner._apply_terraform()
+    template_runner._apply_terraform(msg="Remote State")
     captured = capsys.readouterr()
 
     assert expected in captured.out


### PR DESCRIPTION
This PR updates some misleading and inaccurate messages displayed by Matcha when Terraform apply has finished for both the remote state and general resources.

## Checklist

Please ensure you have done the following:

* [x] I have read the [CONTRIBUTING](https://github.com/fuzzylabs/matcha/blob/main/CONTRIBUTING.md) guide.
* [x] I have updated the documentation if required.
* [x] I have added tests which cover my changes.

## Type of change

Tick all those that apply:

* [x] Bug Fix (non-breaking change, fixing an issue)
* [ ] New feature (non-breaking change to add functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Other (add details above)
