### PR TITLE
[RPD-263] add inference of zenml version from environment

### DIFF
--- a/src/matcha_ml/core/core.py
+++ b/src/matcha_ml/core/core.py
@@ -35,7 +35,8 @@ def zenml_version_is_supported() -> bool:
             )
             return False
     except:
-        warn(f"No local installation of ZenMl found. Defaulting to version {MAJOR_MINOR_ZENML_VERSION}.")
+        warn(f"No local installation of ZenMl found. Defaulting to version {MAJOR_MINOR_ZENML_VERSION} for remote "
+             f"resources.")
         return True
 
 

--- a/src/matcha_ml/core/core.py
+++ b/src/matcha_ml/core/core.py
@@ -19,7 +19,7 @@ from matcha_ml.templates.azure_template import AzureTemplate
 MAJOR_MINOR_ZENML_VERSION = "0.36"
 
 
-def zenml_version_is_supported() -> bool:
+def zenml_version_is_supported() -> None:
     """Check the zenml version of the local environment against the version matcha is expecting.
 
     Returns:
@@ -27,17 +27,13 @@ def zenml_version_is_supported() -> bool:
     """
     try:
         import zenml
-        if zenml.__version__[:3] == MAJOR_MINOR_ZENML_VERSION:
-            return True
-        else:
+        if zenml.__version__[:3] != MAJOR_MINOR_ZENML_VERSION:
             warn(
                 f"Matcha expects ZenML version {MAJOR_MINOR_ZENML_VERSION}.x, but you have version {zenml.__version__}."
             )
-            return False
     except:
         warn(f"No local installation of ZenMl found. Defaulting to version {MAJOR_MINOR_ZENML_VERSION} for remote "
              f"resources.")
-        return True
 
 
 @track(event_name=AnalyticsEvent.GET)
@@ -211,6 +207,7 @@ def provision(
         MatchaError: If prefix is not valid.
         MatchaError: If region is not valid.
     """
+    zenml_version_is_supported()
     remote_state_manager = RemoteStateManager()
     template_runner = AzureRunner()
 

--- a/src/matcha_ml/core/core.py
+++ b/src/matcha_ml/core/core.py
@@ -20,11 +20,7 @@ MAJOR_MINOR_ZENML_VERSION = "0.36"
 
 
 def zenml_version_is_supported() -> None:
-    """Check the zenml version of the local environment against the version matcha is expecting.
-
-    Returns:
-        True if the local zenml version is what matcha expects, False otherwise.
-    """
+    """Check the zenml version of the local environment against the version matcha is expecting."""
     try:
         import zenml
         if zenml.__version__[:3] != MAJOR_MINOR_ZENML_VERSION:

--- a/src/matcha_ml/core/core.py
+++ b/src/matcha_ml/core/core.py
@@ -1,6 +1,7 @@
 """The core functionality for Matcha API."""
 import os
 from typing import Optional
+from warnings import warn
 
 from matcha_ml.cli._validation import get_command_validation
 from matcha_ml.cli.ui.print_messages import print_status
@@ -13,6 +14,29 @@ from matcha_ml.services.global_parameters_service import GlobalParameters
 from matcha_ml.state import MatchaStateService, RemoteStateManager
 from matcha_ml.state.matcha_state import MatchaState
 from matcha_ml.templates.azure_template import AzureTemplate
+
+
+MAJOR_MINOR_ZENML_VERSION = "0.36"
+
+
+def zenml_version_is_supported() -> bool:
+    """Check the zenml version of the local environment against the version matcha is expecting.
+
+    Returns:
+        True if the local zenml version is what matcha expects, False otherwise.
+    """
+    try:
+        import zenml
+        if zenml.__version__[:3] == MAJOR_MINOR_ZENML_VERSION:
+            return True
+        else:
+            warn(
+                f"Matcha expects ZenML version {MAJOR_MINOR_ZENML_VERSION}.x, but you have version {zenml.__version__}."
+            )
+            return False
+    except:
+        warn(f"No local installation of ZenMl found. Defaulting to version {MAJOR_MINOR_ZENML_VERSION}.")
+        return True
 
 
 @track(event_name=AnalyticsEvent.GET)


### PR DESCRIPTION
This PR adds code which checks the zenml version of the environment from which matcha is run. If it is not the expected version, a warning is shown at the start of the provisioning workflow but the user can continue. If no zenml is found locally, again the user can continue and a warning is shown at the start of the provisioning workflow.

## Checklist

Please ensure you have done the following:

* [x] I have read the [CONTRIBUTING](https://github.com/fuzzylabs/matcha/blob/main/CONTRIBUTING.md) guide.
* [ ] I have updated the documentation if required.
* [ ] I have added tests which cover my changes.

## Type of change

Tick all those that apply:

* [ ] Bug Fix (non-breaking change, fixing an issue)
* [ ] New feature (non-breaking change to add functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Other (add details above)
