### PR TITLE
[RPD-282] adds stack cli command

### DIFF
--- a/src/matcha_ml/cli/cli.py
+++ b/src/matcha_ml/cli/cli.py
@@ -27,10 +27,16 @@ from matcha_ml.errors import MatchaError, MatchaInputError
 
 app = typer.Typer(no_args_is_help=True, pretty_exceptions_show_locals=False)
 analytics_app = typer.Typer(no_args_is_help=True, pretty_exceptions_show_locals=False)
+stack_app = typer.Typer(no_args_is_help=True, pretty_exceptions_show_locals=False)
 app.add_typer(
     analytics_app,
     name="analytics",
     help="Enable or disable the collection of anonymous usage data (enabled by default).",
+)
+app.add_typer(
+    stack_app,
+    name="stack",
+    help="Configure the stack for Matcha to provision.",
 )
 
 
@@ -240,6 +246,23 @@ def opt_in() -> None:
         "Thank you for enabling data collection, this helps us improve matcha and anonymously understand how people are using the tool."
     )
     core.analytics_opt_in()
+
+
+@stack_app.command(help="Define the stack for Matcha to provision.")
+def set(stack: str = typer.Argument("default")) -> None:
+    """Define the stack for Matcha to provision.
+
+    Args:
+        stack (Optional[str]): the name of the stack to provision.
+
+    Raises:
+        Exit: Exit if input is not a defined stack.
+    """
+    try:
+        core.stack_set(stack)
+    except MatchaInputError as e:
+        print_error(str(e))
+        raise typer.Exit()
 
 
 if __name__ == "__main__":

--- a/src/matcha_ml/core/__init__.py
+++ b/src/matcha_ml/core/__init__.py
@@ -6,6 +6,7 @@ from .core import (
     get,
     provision,
     remove_state_lock,
+    stack_set,
 )
 
 __all__ = [
@@ -15,4 +16,5 @@ __all__ = [
     "remove_state_lock",
     "destroy",
     "provision",
+    "stack_set",
 ]

--- a/src/matcha_ml/core/core.py
+++ b/src/matcha_ml/core/core.py
@@ -15,7 +15,6 @@ from matcha_ml.state import MatchaStateService, RemoteStateManager
 from matcha_ml.state.matcha_state import MatchaState
 from matcha_ml.templates.azure_template import AzureTemplate
 
-
 MAJOR_MINOR_ZENML_VERSION = "0.36"
 
 
@@ -23,13 +22,16 @@ def zenml_version_is_supported() -> None:
     """Check the zenml version of the local environment against the version matcha is expecting."""
     try:
         import zenml
+
         if zenml.__version__[:3] != MAJOR_MINOR_ZENML_VERSION:
             warn(
                 f"Matcha expects ZenML version {MAJOR_MINOR_ZENML_VERSION}.x, but you have version {zenml.__version__}."
             )
     except:
-        warn(f"No local installation of ZenMl found. Defaulting to version {MAJOR_MINOR_ZENML_VERSION} for remote "
-             f"resources.")
+        warn(
+            f"No local installation of ZenMl found. Defaulting to version {MAJOR_MINOR_ZENML_VERSION} for remote "
+            f"resources."
+        )
 
 
 @track(event_name=AnalyticsEvent.GET)
@@ -259,3 +261,8 @@ def provision(
         matcha_state_service = MatchaStateService()
 
         return matcha_state_service.fetch_resources_from_state_file()
+
+
+def stack_set(stack: str) -> str:
+    """Placeholder for core matcha stack set functionality."""
+    return stack

--- a/tests/test_cli/test_stack.py
+++ b/tests/test_cli/test_stack.py
@@ -1,0 +1,74 @@
+"""Test suit to test the stack command and all its subcommands."""
+from unittest.mock import patch
+
+from typer.testing import CliRunner
+
+from matcha_ml.cli.cli import app
+
+INTERNAL_FUNCTION_STUB = "matcha_ml.core"
+
+
+def test_cli_stack_command_help_option(runner: CliRunner) -> None:
+    """Tests the --help option for the cli analytics command.
+
+    Args:
+        runner (CliRunner): typer CLI runner
+    """
+    # Invoke analytics command with help option
+    result = runner.invoke(app, ["stack", "--help"])
+
+    # Exit code 0 means there was no error
+    assert result.exit_code == 0
+
+    # Assert string is present in cli output
+    assert "Configure the stack for Matcha to provision." in result.stdout
+
+
+def test_cli_stack_command_defaults_to_help(runner: CliRunner) -> None:
+    """Tests the --help option for the cli analytics command.
+
+    Args:
+        runner (CliRunner): typer CLI runner
+    """
+    # Invoke analytics command with help option
+    result = runner.invoke(app, ["stack"])
+
+    # Exit code 0 means there was no error
+    assert result.exit_code == 0
+
+    # Assert string is present in cli output
+    assert "Configure the stack for Matcha to provision." in result.stdout
+
+
+def test_cli_stack_set_command_help_option(runner: CliRunner) -> None:
+    """Tests the --help option for the cli analytics command.
+
+    Args:
+        runner (CliRunner): typer CLI runner
+    """
+    # Invoke analytics command with help option
+    result = runner.invoke(app, ["stack", "set", "--help"])
+
+    # Exit code 0 means there was no error
+    assert result.exit_code == 0
+
+    # Assert string is present in cli output
+    assert "Define the stack for Matcha to provision." in result.stdout
+
+
+def test_cli_stack_set_command(runner: CliRunner) -> None:
+    """Tests the cli stack set command.
+
+    Args:
+        runner (CliRunner): typer CLI runner
+    """
+    with patch(f"{INTERNAL_FUNCTION_STUB}.stack_set") as mocked_stack_set:
+
+        # Invoke analytics command and opt-in sub-command
+        result = runner.invoke(app, ["stack", "set", "test_stack"])
+
+        # Exit code 0 means there was no error
+        assert result.exit_code == 0
+
+        # Assert core.analytics_opt_out is called
+        mocked_stack_set.assert_called_once_with("test_stack")


### PR DESCRIPTION
This PR introduces a new CLI command (`stack`) and sub-command (`set`). This pattern (command and subcommand) is consistent with our implementation of the analytics commands and allows for the `stack` command to be extensible for future functionality (e.g. `matcha stack list`, `matcha stack reset`).

The `stack set` command chain will take an argument - the stack to be provisioned by matcha - and propagate it through to the core module. It will also propagate errors back to the user where relevant.

## Checklist

Please ensure you have done the following:

* [x] I have read the [CONTRIBUTING](https://github.com/fuzzylabs/matcha/blob/main/CONTRIBUTING.md) guide.
* [ ] I have updated the documentation if required.
* [ ] I have added tests which cover my changes.

## Type of change

Tick all those that apply:

* [ ] Bug Fix (non-breaking change, fixing an issue)
* [x] New feature (non-breaking change to add functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Other (add details above)
