### PR TITLE
[RPD-287] ZenML version inference for zenserver

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,10 @@ on:
     branches:
       - main
       - develop
-      - '**feature**'
+      - 'feature/*'
+      - 'hotfix/*'
+      - 'release/*'
+      - 'fixes/*'
   push:
     branches:
       - main

--- a/src/matcha_ml/core/core.py
+++ b/src/matcha_ml/core/core.py
@@ -202,7 +202,6 @@ def provision(
         MatchaError: If prefix is not valid.
         MatchaError: If region is not valid.
     """
-    # zenml_version_is_supported()
     remote_state_manager = RemoteStateManager()
     template_runner = AzureRunner()
 

--- a/src/matcha_ml/core/core.py
+++ b/src/matcha_ml/core/core.py
@@ -203,7 +203,7 @@ def provision(
         MatchaError: If prefix is not valid.
         MatchaError: If region is not valid.
     """
-    zenml_version_is_supported()
+    # zenml_version_is_supported()
     remote_state_manager = RemoteStateManager()
     template_runner = AzureRunner()
 
@@ -249,8 +249,13 @@ def provision(
 
         azure_template = AzureTemplate()
 
+        try:
+            import zenml
+            zenml_version = zenml.__version__
+        except:
+            zenml_version = "latest"
         config = azure_template.build_template_configuration(
-            location=location, prefix=prefix, password=password
+            location=location, prefix=prefix, password=password, zenmlserver_image_tag=zenml_version
         )
         azure_template.build_template(config, template, destination, verbose)
 

--- a/src/matcha_ml/infrastructure/resources/.terraform.lock.hcl
+++ b/src/matcha_ml/infrastructure/resources/.terraform.lock.hcl
@@ -6,6 +6,7 @@ provider "registry.terraform.io/gavinbunney/kubectl" {
   constraints = "1.14.0"
   hashes = [
     "h1:gLFn+RvP37sVzp9qnFCwngRjjFV649r6apjxvJ1E/SE=",
+    "h1:mX2AOFIMIxJmW5kM8DT51gloIOKCr9iT6W8yodnUyfs=",
     "zh:0350f3122ff711984bbc36f6093c1fe19043173fad5a904bce27f86afe3cc858",
     "zh:07ca36c7aa7533e8325b38232c77c04d6ef1081cb0bac9d56e8ccd51f12f2030",
     "zh:0c351afd91d9e994a71fe64bbd1662d0024006b3493bb61d46c23ea3e42a7cf5",
@@ -20,9 +21,10 @@ provider "registry.terraform.io/gavinbunney/kubectl" {
 
 provider "registry.terraform.io/hashicorp/azurerm" {
   version     = "3.48.0"
-  constraints = "3.48.0"
+  constraints = ">= 3.16.0, 3.48.0"
   hashes = [
     "h1:5sGcXKelc4o4MnPZfKKs9pd8w969TtlCV+0IZvW58Cs=",
+    "h1:RSUCtxgd6hD9J11YZGOA4yffeu5P8YmQnP5SRNl6+d8=",
     "zh:01bd328009f2803ebc18ac27535e7d1548c735bb5bd02460e471acc835e5dd19",
     "zh:070b0bdd5ff27232eec7ef9128fc9bd17e6bdae503ddcc450c944449f3a8d216",
     "zh:0a0a0e81f7ab8757aa83876fffbc57328843664900923d8b3c577e7596884726",
@@ -41,6 +43,7 @@ provider "registry.terraform.io/hashicorp/azurerm" {
 provider "registry.terraform.io/hashicorp/external" {
   version = "2.3.1"
   hashes = [
+    "h1:9rJggijNdRdFk//ViQPGZdK0xu9XU/9qBDijNsZJMg0=",
     "h1:bROCw6g5D/3fFnWeJ01L4IrdnJl1ILU8DGDgXCtYzaY=",
     "zh:001e2886dc81fc98cf17cf34c0d53cb2dae1e869464792576e11b0f34ee92f54",
     "zh:2eeac58dd75b1abdf91945ac4284c9ccb2bfb17fa9bdb5f5d408148ff553b3ee",
@@ -61,6 +64,7 @@ provider "registry.terraform.io/hashicorp/helm" {
   version     = "2.0.3"
   constraints = "~> 2.0.1"
   hashes = [
+    "h1:FRSVqY+1/AUO/j/lVxHHsLudfSA9gDc7Dsu+YxcJSEY=",
     "h1:eUr4dHyxlcLmLja0wBgJC7t5bfHzbtACyuumKPuDrGs=",
     "zh:154e0aa489e474e2eeb3de94be7666133faf6fd950712a640425b2bf3a81ee95",
     "zh:16a2be6c4b61d0c5205c63816148c7ab0c8f56a75c05e8d897fa4d5cac0c029a",
@@ -80,6 +84,7 @@ provider "registry.terraform.io/hashicorp/kubernetes" {
   version     = "2.11.0"
   constraints = "~> 2.11.0"
   hashes = [
+    "h1:T65SZhN/tQgsAsHe/G5PCgpjofi+aTKPZ+nZg6WOJpc=",
     "h1:pJiAJwZKUaoAJ4x+3ONJkwEVkjrwGROCGFgj7noPO58=",
     "zh:143a19dd0ea3b07fc5e3d9231f3c2d01f92894385c98a67327de74c76c715843",
     "zh:1fc757d209e09c3cf7848e4274daa32408c07743698fbed10ee52a4a479b62b6",
@@ -101,6 +106,7 @@ provider "registry.terraform.io/hashicorp/local" {
   constraints = "2.1.0"
   hashes = [
     "h1:EYZdckuGU3n6APs97nS2LxZm3dDtGqyM4qaIvsmac8o=",
+    "h1:KfieWtVyGWwplSoLIB5usKAUnrIkDQBkWaR5TI+4WYg=",
     "zh:0f1ec65101fa35050978d483d6e8916664b7556800348456ff3d09454ac1eae2",
     "zh:36e42ac19f5d68467aacf07e6adcf83c7486f2e5b5f4339e9671f68525fc87ab",
     "zh:6db9db2a1819e77b1642ec3b5e95042b202aee8151a0256d289f2e141bf3ceb3",
@@ -120,6 +126,7 @@ provider "registry.terraform.io/hashicorp/null" {
   constraints = "3.2.1"
   hashes = [
     "h1:FbGfc+muBsC17Ohy5g806iuI1hQc4SIexpYCrQHQd8w=",
+    "h1:tSj1mL6OQ8ILGqR2mDu7OYYYWf+hoir0pf9KAQ8IzO8=",
     "zh:58ed64389620cc7b82f01332e27723856422820cfd302e304b5f6c3436fb9840",
     "zh:62a5cc82c3b2ddef7ef3a6f2fedb7b9b3deff4ab7b414938b08e51d6e8be87cb",
     "zh:63cff4de03af983175a7e37e52d4bd89d990be256b16b5c7f919aff5ad485aa5",
@@ -140,6 +147,7 @@ provider "registry.terraform.io/hashicorp/random" {
   constraints = "3.1.0"
   hashes = [
     "h1:BZMEPucF+pbu9gsPk0G0BHx7YP04+tKdq2MrRDF1EDM=",
+    "h1:rKYu5ZUbXwrLG1w81k7H3nce/Ys6yAxXhWcbtk36HjY=",
     "zh:2bbb3339f0643b5daa07480ef4397bd23a79963cc364cdfbb4e86354cb7725bc",
     "zh:3cd456047805bf639fbf2c761b1848880ea703a054f76db51852008b11008626",
     "zh:4f251b0eda5bb5e3dc26ea4400dba200018213654b69b4a5f96abee815b4f5ff",
@@ -158,6 +166,7 @@ provider "registry.terraform.io/loafoe/htpasswd" {
   version     = "1.0.4"
   constraints = "1.0.4"
   hashes = [
+    "h1:/OCwJ2uB9PfESHNn4bDwdHnMOp8x5D/aNvvUl8XNFA4=",
     "h1:v/EZlkxlFBRlLIK2rmgbksuhbxOwenP3TQvreUhCAtE=",
     "zh:1f17ffcb8ab2f19de1242a6980f78334fc81efeaddfa85545435048f54045e4a",
     "zh:6265fd9bbb718d55655120044b4969c80aa938ecfb17a0fd7541ff7de8c54e1e",

--- a/src/matcha_ml/infrastructure/resources/main.tf
+++ b/src/matcha_ml/infrastructure/resources/main.tf
@@ -80,7 +80,7 @@ module "zenserver" {
   username = var.username
   password = var.password
 
-  zenmlserver_image_tag = var.zenmlserver_image_tag
+  zenmlserver_version = var.zenmlserver_version
 }
 
 

--- a/src/matcha_ml/infrastructure/resources/main.tf
+++ b/src/matcha_ml/infrastructure/resources/main.tf
@@ -79,6 +79,8 @@ module "zenserver" {
   # ZenServer credentials
   username = var.username
   password = var.password
+
+  zenmlserver_image_tag = var.zenmlserver_image_tag
 }
 
 

--- a/src/matcha_ml/infrastructure/resources/variables.tf
+++ b/src/matcha_ml/infrastructure/resources/variables.tf
@@ -21,7 +21,7 @@ variable "password" {
   sensitive   = true
 }
 
-variable "zenmlserver_image_tag" {
+variable "zenmlserver_version" {
   description = "The tag to use for the zenmlserver docker image."
   default     = "latest"
   type        = string

--- a/src/matcha_ml/infrastructure/resources/variables.tf
+++ b/src/matcha_ml/infrastructure/resources/variables.tf
@@ -21,6 +21,12 @@ variable "password" {
   sensitive   = true
 }
 
+variable "zenmlserver_image_tag" {
+  description = "The tag to use for the zenmlserver docker image."
+  default     = "latest"
+  type        = string
+}
+
 # seldon variables
 variable "seldon_name" {
   description = "Name of the Seldon deployment"

--- a/src/matcha_ml/infrastructure/resources/zen_server/main.tf
+++ b/src/matcha_ml/infrastructure/resources/zen_server/main.tf
@@ -86,6 +86,10 @@ resource "helm_release" "zen_server" {
     name  = "zenml.database.sslVerifyServerCert"
     value = var.deploy_db ? false : var.database_ssl_verify_server_cert
   }
+  set {
+    name = "zenml.image.tag"
+    value = var.zenmlserver_image_tag
+  }
   depends_on = [
     resource.kubernetes_namespace.zen_server
   ]

--- a/src/matcha_ml/infrastructure/resources/zen_server/main.tf
+++ b/src/matcha_ml/infrastructure/resources/zen_server/main.tf
@@ -87,8 +87,8 @@ resource "helm_release" "zen_server" {
     value = var.deploy_db ? false : var.database_ssl_verify_server_cert
   }
   set {
-    name = "zenml.image.tag"
-    value = var.zenmlserver_image_tag
+    name = "zenml.version"
+    value = var.zenmlserver_version
   }
   depends_on = [
     resource.kubernetes_namespace.zen_server

--- a/src/matcha_ml/infrastructure/resources/zen_server/main.tf
+++ b/src/matcha_ml/infrastructure/resources/zen_server/main.tf
@@ -87,7 +87,7 @@ resource "helm_release" "zen_server" {
     value = var.deploy_db ? false : var.database_ssl_verify_server_cert
   }
   set {
-    name = "zenml.version"
+    name = zenml.image.tag
     value = var.zenmlserver_version
   }
   depends_on = [

--- a/src/matcha_ml/infrastructure/resources/zen_server/main.tf
+++ b/src/matcha_ml/infrastructure/resources/zen_server/main.tf
@@ -87,7 +87,7 @@ resource "helm_release" "zen_server" {
     value = var.deploy_db ? false : var.database_ssl_verify_server_cert
   }
   set {
-    name = zenml.image.tag
+    name = "zenml.image.tag"
     value = var.zenmlserver_version
   }
   depends_on = [

--- a/src/matcha_ml/infrastructure/resources/zen_server/variables.tf
+++ b/src/matcha_ml/infrastructure/resources/zen_server/variables.tf
@@ -163,6 +163,5 @@ variable "zenmlserver_image_repo" {
 }
 variable "zenmlserver_image_tag" {
   description = "The tag to use for the zenmlserver docker image."
-  default     = "latest"
   type        = string
 }

--- a/src/matcha_ml/infrastructure/resources/zen_server/variables.tf
+++ b/src/matcha_ml/infrastructure/resources/zen_server/variables.tf
@@ -161,7 +161,7 @@ variable "zenmlserver_image_repo" {
   default     = "zenmldocker/zenml-server"
   type        = string
 }
-variable "zenmlserver_image_tag" {
+variable "zenmlserver_version" {
   description = "The tag to use for the zenmlserver docker image."
   type        = string
 }

--- a/src/matcha_ml/infrastructure/resources/zen_server/zenml_helm/Chart.yaml
+++ b/src/matcha_ml/infrastructure/resources/zen_server/zenml_helm/Chart.yaml
@@ -9,5 +9,5 @@ keywords:
 home: https://zenml.io
 sources:
 - https://github.com/zenml-io/zenml
-icon: https://raw.githubusercontent.com/zenml-io/zenml/main/docs/book/assets/zenml_logo.png
-appVersion: "0.36.1"
+icon: https://raw.githubusercontent.com/zenml-io/zenml/main/docs/book/.gitbook/assets/zenml_logo.png
+appVersion: "0.42.1"

--- a/src/matcha_ml/infrastructure/resources/zen_server/zenml_helm/templates/server-deployment.yaml
+++ b/src/matcha_ml/infrastructure/resources/zen_server/zenml_helm/templates/server-deployment.yaml
@@ -55,13 +55,8 @@ spec:
             - name: ZENML_LOGGING_VERBOSITY
               value: "DEBUG"
             {{- end }}
-            {{- if .Values.zenml.analyticsOptIn }}
-            - name: ZENML_ANALYTICS_OPT_IN
-              value: "True"
-            {{- else if not .Values.zenml.analyticsOptIn }}
             - name: ZENML_ANALYTICS_OPT_IN
               value: "False"
-            {{- end }}
             - name: ZENML_DEFAULT_PROJECT_NAME
               value: {{ .Values.zenml.defaultProject | quote }}
             - name: ZENML_DEFAULT_USER_NAME
@@ -153,6 +148,10 @@ spec:
               value: {{ .Values.zenml.defaultProject | quote }}
             - name: ZENML_DEFAULT_USER_NAME
               value: {{ .Values.zenml.defaultUsername | quote }}
+            {{- if .Values.zenml.enableImplicitAuthMethods }}
+            - name: ZENML_ENABLE_IMPLICIT_AUTH_METHODS
+              value: "True"
+            {{- end }}
             {{- if .Values.zenml.database.url }}
             - name: ZENML_STORE_TYPE
               value: sql

--- a/src/matcha_ml/infrastructure/resources/zen_server/zenml_helm/templates/server-ingress.yaml
+++ b/src/matcha_ml/infrastructure/resources/zen_server/zenml_helm/templates/server-ingress.yaml
@@ -6,7 +6,7 @@
   {{- $_ := set .Values.zenml.ingress.annotations "kubernetes.io/ingress.class" .Values.zenml.ingress.className}}
   {{- end }}
 {{- end }}
-{{- if $.Values.zenml.ingress.tls.enabled }}
+{{- if and $.Values.zenml.ingress.tls.enabled (eq .Values.zenml.ingress.className "nginx") }}
   {{- $_ := set .Values.zenml.ingress.annotations "nginx.ingress.kubernetes.io/ssl-redirect" "true"}}
 {{- end }}
 

--- a/src/matcha_ml/infrastructure/resources/zen_server/zenml_helm/values.yaml
+++ b/src/matcha_ml/infrastructure/resources/zen_server/zenml_helm/values.yaml
@@ -4,8 +4,10 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
+
 # ZenML server related options.
 zenml:
+
   replicaCount: 1
 
   image:
@@ -24,7 +26,7 @@ zenml:
   deploymentType:
 
   # The ZenML authentication scheme. Use one of:
-  #
+  # 
   # NO_AUTH - No authentication
   # HTTP_BASIC - HTTP Basic authentication
   # OAUTH2_PASSWORD_BEARER - OAuth2 password bearer with JWT tokens
@@ -38,7 +40,7 @@ zenml:
   #   from secrets import token_hex
   #   token_hex(32)
   #   ```
-  #
+  #   
   # or:
   #
   #   ```shell
@@ -70,20 +72,27 @@ zenml:
   # Use your own password here
   defaultPassword: zenml
 
+  # Implicit authentication methods featured by service connectors that support
+  # them are disabled by default, for security reasons. This is because they
+  # allow users to authenticate to the cloud provider where ZenML is running
+  # without having to provide any credentials.
+  enableImplicitAuthMethods: false
+
   # MySQL database configuration. If not set, a local sqlite database will be
   # used, which will not be persisted across pod restarts.
   # NOTE: the certificate files need to be copied in the helm chart folder and
   # the paths configured here need to be relative to the root of the helm chart.
-  database:
-    {}
+  database: {}
     # url: "mysql://admin:password@zenml-mysql:3306/database"
     # sslCa: /path/to/ca.pem
     # sslCert: /path/to/client-cert.pem
     # sslKey: /path/to/client-key.pem
     # sslVerifyServerCert: True
 
+
   # Secrets store settings. This is used to store centralized secrets.
   secretsStore:
+
     # Set to false to disable the secrets store.
     enabled: true
 
@@ -106,6 +115,7 @@ zenml:
     # SQL secrets store configuration. Only relevant if the `sql` secrets store
     # type is configured.
     sql:
+
       # The secret key used to encrypt secrets in the SQL database. Only relevant
       # if the SQL secrets store type is used. This should be set to a random
       # string with a recommended length of at least 32 characters, e.g.:
@@ -114,7 +124,7 @@ zenml:
       #   from secrets import token_hex
       #   token_hex(32)
       #   ```
-      #
+      #   
       # or:
       #
       #   ```shell
@@ -135,6 +145,7 @@ zenml:
     # AWS secrets store configuration. Only relevant if the `aws` secrets store
     # type is configured.
     aws:
+
       # The AWS region to use. This must be set to the region where the AWS
       # Secrets Manager service that you want to use is located.
       region_name: us-east-1
@@ -160,9 +171,11 @@ zenml:
       # starvation in the ZenML server on high load.
       secret_list_refresh_timeout: 0
 
+
     # GCP secrets store configuration. Only relevant if the `gcp` secrets store
     # type is configured.
     gcp:
+
       # The GCP project ID to use. This must be set to the project ID where the
       # GCP Secrets Manager service that you want to use is located.
       project_id: my-gcp-project
@@ -179,6 +192,7 @@ zenml:
     # AWS Key Vault secrets store configuration. Only relevant if the `azure`
     # secrets store type is configured.
     azure:
+
       # The name of the Azure Key Vault. This must be set to point to the Azure
       # Key Vault instance that you want to use.
       key_vault_name:
@@ -197,6 +211,7 @@ zenml:
     # HashiCorp Vault secrets store configuration. Only relevant if the `hashicorp`
     # secrets store type is configured
     hashicorp:
+
       # The url of the HashiCorp Vault server
       vault_addr: https://vault.example.com
       # The token used to authenticate with the Vault server
@@ -210,6 +225,7 @@ zenml:
     # Custom secrets store configuration. Only relevant if the `custom` secrets
     # store type is configured.
     custom:
+
       # The class path of the custom secrets store implementation. This should
       # point to a full Python class that extends the
       # `zenml.zen_stores.secrets_stores.base_secrets_store.BaseSecretsStore`
@@ -234,11 +250,11 @@ zenml:
   secretEnvironment: {}
 
   service:
-    type: LoadBalancer # Changed from ClusterIP
+    type: LoadBalancer  # changed from ClusterIP
     port: 80
 
   ingress:
-    enabled: false # Changed from true
+    enabled: false  # changed from true
     className: "nginx"
     annotations:
       nginx.ingress.kubernetes.io/ssl-redirect: "true"
@@ -262,6 +278,7 @@ zenml:
       generateCerts: false
       secretName: zenml-tls-certs
 
+
 serviceAccount:
   # Specifies whether a service account should be created
   create: true
@@ -273,8 +290,7 @@ serviceAccount:
 
 podAnnotations: {}
 
-podSecurityContext:
-  {}
+podSecurityContext: {}
   # fsGroup: 2000
 
 securityContext:
@@ -284,8 +300,7 @@ securityContext:
   #   drop:
   #   - ALL
 
-resources:
-  {}
+resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
   # resources, such as Minikube. If you do want to specify resources, uncomment the following

--- a/tests/test_cli/test_provision.py
+++ b/tests/test_cli/test_provision.py
@@ -143,6 +143,7 @@ def test_cli_provision_command(
         "location": "uksouth",
         "prefix": "matcha",
         "password": "default",
+        "zenmlserver_version": "latest"
     }
 
     assert_infrastructure(
@@ -199,6 +200,7 @@ def test_cli_provision_command_with_args(
         "location": "uksouth",
         "prefix": "matcha",
         "password": "ninja",
+        "zenmlserver_version": "latest"
     }
 
     assert_infrastructure(
@@ -245,6 +247,7 @@ def test_cli_provision_command_with_prefix(
         "location": "uksouth",
         "prefix": "coffee",
         "password": "default",
+        "zenmlserver_version": "latest"
     }
 
     assert_infrastructure(
@@ -289,6 +292,7 @@ def test_cli_provision_command_with_default_prefix(
         "location": "uksouth",
         "prefix": "matcha",
         "password": "default",
+        "zenmlserver_version": "latest"
     }
 
     assert_infrastructure(

--- a/tests/test_core/test_core_provision.py
+++ b/tests/test_core/test_core_provision.py
@@ -6,11 +6,12 @@ import uuid
 from pathlib import Path
 from typing import Dict, Iterator, Union
 from unittest import mock
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
 from matcha_ml.core import provision
+from matcha_ml.core.core import infer_zenml_version
 from matcha_ml.core._validation import LONGEST_RESOURCE_NAME, MAXIMUM_RESOURCE_NAME_LEN
 from matcha_ml.errors import MatchaError, MatchaInputError
 from matcha_ml.services.global_parameters_service import GlobalParameters
@@ -334,3 +335,9 @@ def test_stale_remote_state_file_is_removed(matcha_testing_directory: str):
         config_file_contents = json.load(f)
 
     assert expected_config_file_contents == config_file_contents
+
+
+def test_version_inference_latest():
+    """Test checking when zenml isn't installed, the latest version is returned."""
+    assert infer_zenml_version() == "latest"
+

--- a/tests/test_core/test_core_provision.py
+++ b/tests/test_core/test_core_provision.py
@@ -210,6 +210,7 @@ def test_provision_copies_infrastructure_templates_with_specified_values(
         "location": "uksouth",
         "prefix": "coffee",
         "password": "default",
+        "zenmlserver_version": "latest"
     }
 
     assert_infrastructure(


### PR DESCRIPTION
This PR has matcha look for a local install of zenml in the environment from which it was launched, then sets the version to be installed on the remote resources accordingly. If no installation is found, then the most recent release of zen server is installed instead.

Most of the changes are to terraform files, where a new variable has been introduced. On the python side, the version is passed to `build_template_configuration` after it is inferred by new `infer_zenml_version` function. This function also prints to the terminal information regarding the selected zenml version.


## Checklist

Please ensure you have done the following:

* [x] I have read the [CONTRIBUTING](https://github.com/fuzzylabs/matcha/blob/main/CONTRIBUTING.md) guide.
* [ ] I have updated the documentation if required.
* [ ] I have added tests which cover my changes.

## Type of change

Tick all those that apply:

* [ ] Bug Fix (non-breaking change, fixing an issue)
* [x] New feature (non-breaking change to add functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Other (add details above)
