### PR TITLE
[RPD-259] Refactor `build_state_from_terraform_output` within `matcha_state.py` to use objects defined within matcha_state.py

### DIFF
--- a/src/matcha_ml/services/analytics_service.py
+++ b/src/matcha_ml/services/analytics_service.py
@@ -53,9 +53,14 @@ def _get_state_uuid() -> Optional[MatchaResourceProperty]:
     except MatchaError:
         return None
 
-    try:
-        state_id_component = matcha_state_service.get_component("id")
-    except MatchaError:
+    # try:
+
+    # except MatchaError:
+    #     return None
+
+    state_id_component = matcha_state_service.get_component("id")
+
+    if state_id_component is None:
         return None
 
     matcha_state_uuid = state_id_component.find_property(property_name="matcha_uuid")

--- a/src/matcha_ml/services/analytics_service.py
+++ b/src/matcha_ml/services/analytics_service.py
@@ -53,11 +53,6 @@ def _get_state_uuid() -> Optional[MatchaResourceProperty]:
     except MatchaError:
         return None
 
-    # try:
-
-    # except MatchaError:
-    #     return None
-
     state_id_component = matcha_state_service.get_component("id")
 
     if state_id_component is None:

--- a/src/matcha_ml/state/matcha_state.py
+++ b/src/matcha_ml/state/matcha_state.py
@@ -226,7 +226,7 @@ class MatchaStateService:
             components_list = [
                 component.resource.name for component in matcha_state.components
             ]
-            print(output_name, output_value)
+
             if resource_type.name in components_list:
                 # add just the properties
                 for component in matcha_state.components:

--- a/src/matcha_ml/state/matcha_state.py
+++ b/src/matcha_ml/state/matcha_state.py
@@ -128,7 +128,7 @@ class MatchaStateService:
     def __init__(
         self,
         matcha_state: Optional[MatchaState] = None,
-        terraform_output: Optional[Dict[str, str]] = None,
+        terraform_output: Optional[Dict[str, Dict[str, str]]] = None,
     ) -> None:
         """Constructor for the MatchaStateService.
 
@@ -168,7 +168,7 @@ class MatchaStateService:
         return bool(os.path.isfile(cls.matcha_state_path))
 
     def build_state_from_terraform_output(
-        self, terraform_output: Dict[str, str]
+        self, terraform_output: Dict[str, Dict[str, str]]
     ) -> MatchaState:
         """Builds a MatchaState class from a terraform output dictionary.
 
@@ -210,7 +210,7 @@ class MatchaStateService:
 
             flavor, resource_name = flavor_and_resource_name.split("_", maxsplit=1)
             resource_name = resource_name.replace("_", "-")
-            resource_type = resource_type.name.replace("_", "-")  # type: ignore
+            resource_type.name = resource_type.name.replace("_", "-")
 
             return resource_type, flavor, resource_name
 
@@ -226,14 +226,14 @@ class MatchaStateService:
             components_list = [
                 component.resource.name for component in matcha_state.components
             ]
-
+            print(output_name, output_value)
             if resource_type.name in components_list:
                 # add just the properties
                 for component in matcha_state.components:
                     if resource_type.name == component.resource.name:
                         component.properties.append(
                             MatchaResourceProperty(
-                                name=resource_name, value=output_value
+                                name=resource_name, value=output_value["value"]
                             )
                         )
             else:
@@ -244,7 +244,7 @@ class MatchaStateService:
                         properties=[
                             MatchaResourceProperty(name="flavor", value=flavor),
                             MatchaResourceProperty(
-                                name=resource_name, value=output_value
+                                name=resource_name, value=output_value["value"]
                             ),
                         ],
                     )

--- a/src/matcha_ml/state/matcha_state.py
+++ b/src/matcha_ml/state/matcha_state.py
@@ -242,19 +242,15 @@ class MatchaStateService:
                 resource_name,
             ) = _parse_terraform_output_resource_name(output_name)
 
-            components_list = [
-                component.resource.name for component in matcha_state.components
-            ]
+            component = matcha_state.get_component(resource_type.name)
 
-            if resource_type.name in components_list:
+            if component:
                 # add just the properties
-                for component in matcha_state.components:
-                    if resource_type.name == component.resource.name:
-                        component.properties.append(
-                            MatchaResourceProperty(
-                                name=resource_name, value=output_value["value"]
-                            )
-                        )
+                component.properties.append(
+                    MatchaResourceProperty(
+                        name=resource_name, value=output_value["value"]
+                    )
+                )
             else:
                 # add the component
                 matcha_state.components.append(
@@ -358,7 +354,6 @@ class MatchaStateService:
             return MatchaState(components=[])
 
         if property_name is None:
-
             return MatchaState(components=[component])
 
         property = component.find_property(property_name=property_name)

--- a/src/matcha_ml/state/matcha_state.py
+++ b/src/matcha_ml/state/matcha_state.py
@@ -86,7 +86,7 @@ class MatchaState:
             resource_name (str): the components resource name
 
         Returns:
-            MatchaStateComponent: the state component matching the resource name parameter.
+            Optional[MatchaStateComponent]: the state component matching the resource name parameter.
         """
         component = next(
             filter(
@@ -244,7 +244,7 @@ class MatchaStateService:
 
             component = matcha_state.get_component(resource_type.name)
 
-            if component:
+            if component is not None:
                 # add just the properties
                 component.properties.append(
                     MatchaResourceProperty(
@@ -304,12 +304,6 @@ class MatchaStateService:
     def is_local_state_stale(self) -> bool:
         """Checks for congruence between the local config file and the local state file."""
         local_config_file = os.path.join(os.getcwd(), "matcha.config.json")
-
-        # the resource group name from the state object
-
-        # matcha_state_resource_group: Optional[str] = (
-        #     self.get_component("cloud").find_property("resource-group-name").value
-        # )
 
         cloud_component = self.get_component("cloud")
 

--- a/src/matcha_ml/state/matcha_state.py
+++ b/src/matcha_ml/state/matcha_state.py
@@ -214,7 +214,7 @@ class MatchaStateService:
 
             return resource_type, flavor, resource_name
 
-        matcha_components: List[MatchaStateComponent] = []
+        matcha_state = MatchaState(components=[])
 
         for output_name, output_value in terraform_output.items():
             (
@@ -224,12 +224,12 @@ class MatchaStateService:
             ) = _parse_terraform_output_resource_name(output_name)
 
             components_list = [
-                component.resource.name for component in matcha_components
+                component.resource.name for component in matcha_state.components
             ]
 
             if resource_type.name in components_list:
                 # add just the properties
-                for component in matcha_components:
+                for component in matcha_state.components:
                     if resource_type.name == component.resource.name:
                         component.properties.append(
                             MatchaResourceProperty(
@@ -238,7 +238,7 @@ class MatchaStateService:
                         )
             else:
                 # add the component
-                matcha_components.append(
+                matcha_state.components.append(
                     MatchaStateComponent(
                         resource=resource_type,
                         properties=[
@@ -257,9 +257,9 @@ class MatchaStateService:
                 MatchaResourceProperty(name="matcha_uuid", value=str(uuid.uuid4()))
             ],
         )
-        matcha_components.append(matcha_uuid_component)
+        matcha_state.components.append(matcha_uuid_component)
 
-        return MatchaState(matcha_components)
+        return matcha_state
 
     def _write_state(self, matcha_state: MatchaState) -> None:
         """Writes a given MatchaState object to the matcha.state file.

--- a/tests/test_state/test_matcha_state.py
+++ b/tests/test_state/test_matcha_state.py
@@ -365,13 +365,9 @@ def test_get_component_not_found(
         matcha_state_service (MatchaStateService): the Matcha state service testing instance.
     """
     invalid_resource_name = "not a resource"
-    with pytest.raises(MatchaError) as err:
-        _ = matcha_state_service.get_component(resource_name=invalid_resource_name)
+    component = matcha_state_service.get_component(resource_name=invalid_resource_name)
 
-    assert (
-        str(err.value)
-        == "The component with the name 'not a resource' could not be found in the state."
-    )
+    assert component is None
 
 
 def test_state_component_find_property_expected(


### PR DESCRIPTION
This PR refactors the `build_state_from_terraform_output` method to make use of the custom classes within the `matcha_state.py` module. 

Previously, the `build_state_from_terraform_output` method made use of the `_parse_terraform_output` utility function to build a dictionary representation of state. This dictionary was then converted into a `MatchaState` object using the `from_dict` method in the MatchaState class.

In this new implementation, the `MatchaState` object is built using the relevant classes representing underlying resources, properties and components.

This PR also updates the `get_component` method of the MatchaStateService by moving it to the `MatchaState` object and adding an ability for the method to return `None`. Changes have been made to the broader matcha codebase to account for this change.


## Checklist

Please ensure you have done the following:

* [X] I have read the [CONTRIBUTING](https://github.com/fuzzylabs/matcha/blob/main/CONTRIBUTING.md) guide.
* [ ] I have updated the documentation if required.
* [ ] I have added tests which cover my changes.

## Type of change

Tick all those that apply:

* [ ] Bug Fix (non-breaking change, fixing an issue)
* [ ] New feature (non-breaking change to add functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [X] Other (add details above)
