### PR TITLE
[RPD-290] Update MatchaConfig object to not throw an error when a matching property/component is not found

### DIFF
--- a/src/matcha_ml/config/matcha_config.py
+++ b/src/matcha_ml/config/matcha_config.py
@@ -2,7 +2,7 @@
 import json
 import os
 from dataclasses import dataclass
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 from matcha_ml.errors import MatchaError
 
@@ -57,7 +57,7 @@ class MatchaConfig:
 
     components: List[MatchaConfigComponent]
 
-    def find_component(self, component_name: str) -> MatchaConfigComponent:
+    def find_component(self, component_name: str) -> Optional[MatchaConfigComponent]:
         """Given a component name, find the component that matches it.
 
         Note: this only works under the assumption of none-duplicated properties.
@@ -75,11 +75,6 @@ class MatchaConfig:
             filter(lambda component: component.name == component_name, self.components),
             None,
         )
-
-        if component is None:
-            raise MatchaError(
-                f"The component with the name '{component_name}' could not be found."
-            )
 
         return component
 

--- a/tests/test_config/test_matcha_config.py
+++ b/tests/test_config/test_matcha_config.py
@@ -170,3 +170,35 @@ def test_matcha_config_service_delete_matcha_config_error_handling(
 
     with pytest.raises(MatchaError):
         mocked_matcha_config_service.delete_matcha_config()
+
+
+def test_find_component_expected(
+    mocked_matcha_config: MatchaConfig,
+):
+    """Test that a component is found when a valid component name is given.
+
+    Args:
+        mocked_matcha_config (MatchaConfig): a mocked MatchaConfig instance.
+    """
+    component = mocked_matcha_config.find_component(
+        component_name="remote_state_bucket"
+    )
+
+    assert component.find_property("account_name").value == "test-account"
+    assert component.find_property("container_name").value == "test-container"
+    assert component.find_property("resource_group_name").value == "test-rg"
+
+
+def test_find_component_not_found(
+    mocked_matcha_config: MatchaConfig,
+):
+    """Test that a component is not found when an invalid component name is given.
+
+    Args:
+        mocked_matcha_config (MatchaConfig): a mocked MatchaConfig instance.
+    """
+    component = mocked_matcha_config.find_component(
+        component_name="invalid_resource_name"
+    )
+
+    assert component is None


### PR DESCRIPTION
This PR updates the `find_component` method of the `MatchaConfig` object. Previously, for object representations of state or configuration, the relevant 'find component' method would throw an error if a relevant component could not be found. It was decided that the preferred behaviour would be to return a None value in those instances where a relevant component could not be found.

This PR updates the `find_component` method of the `MatchaConfig` object to return `None` in the event that a relevant component is not found. This PR also adds tests to cover this altered behaviour.

## Checklist

Please ensure you have done the following:

* [x] I have read the [CONTRIBUTING](https://github.com/fuzzylabs/matcha/blob/main/CONTRIBUTING.md) guide.
* [ ] I have updated the documentation if required.
* [X] I have added tests which cover my changes.

## Type of change

Tick all those that apply:

* [ ] Bug Fix (non-breaking change, fixing an issue)
* [ ] New feature (non-breaking change to add functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Other (add details above)
