### PR TITLE
[RPD-292] [BUG] Update AzureTemplate to not create redundant folders during provisioning

### DIFF
--- a/src/matcha_ml/core/core.py
+++ b/src/matcha_ml/core/core.py
@@ -18,7 +18,7 @@ from matcha_ml.services.analytics_service import AnalyticsEvent, track
 from matcha_ml.services.global_parameters_service import GlobalParameters
 from matcha_ml.state import MatchaStateService, RemoteStateManager
 from matcha_ml.state.matcha_state import MatchaState
-from matcha_ml.templates.azure_template import AzureTemplate
+from matcha_ml.templates.azure_template import DEFAULT_STACK, LLM_STACK, AzureTemplate
 
 
 class StackTypeMeta(
@@ -294,7 +294,9 @@ def provision(
             stack_name,
         )
 
-        azure_template = AzureTemplate()
+        azure_template = AzureTemplate(
+            LLM_STACK if stack_name == StackType.LLM.value else DEFAULT_STACK
+        )
 
         zenml_version = infer_zenml_version()
         config = azure_template.build_template_configuration(

--- a/src/matcha_ml/templates/azure_template.py
+++ b/src/matcha_ml/templates/azure_template.py
@@ -1,10 +1,10 @@
 """Build a template for provisioning resources on Azure using terraform files."""
-from typing import Optional
+from typing import List, Optional
 
 from matcha_ml.state import MatchaState, MatchaStateService
 from matcha_ml.templates.base_template import BaseTemplate, TemplateVariables
 
-SUBMODULE_NAMES = [
+DEFAULT_STACK = [
     "aks",
     "resource_group",
     "mlflow_module",
@@ -16,8 +16,8 @@ SUBMODULE_NAMES = [
     "zen_server/zenml_helm",
     "zen_server/zenml_helm/templates",
     "data_version_control_storage",
-    "chroma",
 ]
+LLM_STACK = DEFAULT_STACK + ["chroma"]
 
 
 class AzureTemplate(BaseTemplate):
@@ -27,13 +27,13 @@ class AzureTemplate(BaseTemplate):
         BaseTemplate: The base template class.
     """
 
-    def __init__(self) -> None:
+    def __init__(self, submodule_names: List[str]) -> None:
         """Initialize the StateStorageTemplate with the submodule names.
 
         Args:
             submodule_names (List[str]): A list of submodule names.
         """
-        super().__init__(SUBMODULE_NAMES)
+        super().__init__(submodule_names)
 
     def build_template(
         self,

--- a/src/matcha_ml/templates/azure_template.py
+++ b/src/matcha_ml/templates/azure_template.py
@@ -17,7 +17,11 @@ DEFAULT_STACK = [
     "zen_server/zenml_helm/templates",
     "data_version_control_storage",
 ]
-LLM_STACK = DEFAULT_STACK + ["chroma"]
+LLM_STACK = DEFAULT_STACK + [
+    "chroma",
+    "chroma/chroma_helm",
+    "chroma/chroma_helm/templates",
+]
 
 
 class AzureTemplate(BaseTemplate):

--- a/tests/test_cli/test_provision.py
+++ b/tests/test_cli/test_provision.py
@@ -9,7 +9,7 @@ import pytest
 from typer.testing import CliRunner
 
 from matcha_ml.cli.cli import app
-from matcha_ml.templates.azure_template import SUBMODULE_NAMES
+from matcha_ml.templates.azure_template import DEFAULT_STACK
 
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 TEMPLATE_DIR = os.path.join(
@@ -66,7 +66,7 @@ def assert_infrastructure(
         module_file_path = os.path.join(destination_path, module_file_name)
         assert os.path.exists(module_file_path)
 
-    for module_name in SUBMODULE_NAMES:
+    for module_name in DEFAULT_STACK:
         for module_file_name in glob.glob(
             os.path.join(TEMPLATE_DIR, module_name, "*.tf")
         ):
@@ -143,7 +143,7 @@ def test_cli_provision_command(
         "location": "uksouth",
         "prefix": "matcha",
         "password": "default",
-        "zenmlserver_version": "latest"
+        "zenmlserver_version": "latest",
     }
 
     assert_infrastructure(
@@ -200,7 +200,7 @@ def test_cli_provision_command_with_args(
         "location": "uksouth",
         "prefix": "matcha",
         "password": "ninja",
-        "zenmlserver_version": "latest"
+        "zenmlserver_version": "latest",
     }
 
     assert_infrastructure(
@@ -247,7 +247,7 @@ def test_cli_provision_command_with_prefix(
         "location": "uksouth",
         "prefix": "coffee",
         "password": "default",
-        "zenmlserver_version": "latest"
+        "zenmlserver_version": "latest",
     }
 
     assert_infrastructure(
@@ -292,7 +292,7 @@ def test_cli_provision_command_with_default_prefix(
         "location": "uksouth",
         "prefix": "matcha",
         "password": "default",
-        "zenmlserver_version": "latest"
+        "zenmlserver_version": "latest",
     }
 
     assert_infrastructure(

--- a/tests/test_core/test_core_provision.py
+++ b/tests/test_core/test_core_provision.py
@@ -18,7 +18,7 @@ from matcha_ml.services.global_parameters_service import GlobalParameters
 from matcha_ml.state.matcha_state import (
     MatchaState,
 )
-from matcha_ml.templates.azure_template import SUBMODULE_NAMES
+from matcha_ml.templates.azure_template import DEFAULT_STACK
 
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 
@@ -149,7 +149,7 @@ def assert_infrastructure(
         module_file_path = os.path.join(destination_path, module_file_name)
         assert os.path.exists(module_file_path)
 
-    for module_name in SUBMODULE_NAMES:
+    for module_name in DEFAULT_STACK:
         for module_file_name in glob.glob(
             os.path.join(TEMPLATE_DIR, module_name, "*.tf")
         ):


### PR DESCRIPTION
This PR updates the `azure_template` and `core` modules to dynamically pass lists of components to the template builder depending on which stack has been set by the user.

Currently, the template builder is passed a list of components represented by a constant variable. This PR splits this constant variable into different stacks, which are passed to the template builder depending on what value the user's set stack takes.

## Checklist

Please ensure you have done the following:

* [X] I have read the [CONTRIBUTING](https://github.com/fuzzylabs/matcha/blob/main/CONTRIBUTING.md) guide.
* [ ] I have updated the documentation if required.
* [ ] I have added tests which cover my changes.

## Type of change

Tick all those that apply:

* [X] Bug Fix (non-breaking change, fixing an issue)
* [ ] New feature (non-breaking change to add functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Other (add details above)
