### PR TITLE
[RPD-303] Update `stack_set` docstring to include example and raises

### DIFF
--- a/src/matcha_ml/core/core.py
+++ b/src/matcha_ml/core/core.py
@@ -317,8 +317,17 @@ def provision(
 def stack_set(stack_name: str) -> None:
     """A function for updating the stack type in the local matcha.config.json file.
 
+    Note: This cannot be run once there are provisioned resources.
+
+    Examples:
+        >>> stack_set(stack_name='default')
+
     Args:
         stack_name (str): the name of the type of stack to be specified in the config file.
+
+    Raises:
+        MatchaInputError: if the stack_name is not a valid stack type
+        MatchaError: if there are already resources provisioned.
     """
     if RemoteStateManager().is_state_provisioned():
         raise MatchaError(


### PR DESCRIPTION
The docstring for the `stack_set` core function was missing two components:

1. An example on how to use the function
2. The errors that are raised by the function

Both of these have been added as it's important information for the user.

## Checklist

Please ensure you have done the following:

* [x] I have read the [CONTRIBUTING](https://github.com/fuzzylabs/matcha/blob/main/CONTRIBUTING.md) guide.
* [ ] I have updated the documentation if required.
* [ ] I have added tests which cover my changes.

## Type of change

Tick all those that apply:

* [ ] Bug Fix (non-breaking change, fixing an issue)
* [ ] New feature (non-breaking change to add functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Other (add details above)
