### PR TITLE
[RPD-305] fix circular import error

### DIFF
--- a/src/matcha_ml/runners/base_runner.py
+++ b/src/matcha_ml/runners/base_runner.py
@@ -1,7 +1,8 @@
 """Run terraform templates to provision and deprovision resources."""
 import os
+from abc import abstractmethod
 from multiprocessing.pool import ThreadPool
-from typing import Optional, Tuple
+from typing import Any, Optional
 
 import typer
 
@@ -18,7 +19,6 @@ from matcha_ml.services.terraform_service import (
     TerraformConfig,
     TerraformService,
 )
-from matcha_ml.state.matcha_state import MatchaStateService
 
 SPINNER = "dots"
 
@@ -183,10 +183,12 @@ class BaseRunner:
             if tf_result.return_code != 0:
                 raise MatchaTerraformError(tf_error=tf_result.std_err)
 
-    def provision(self) -> MatchaStateService:
+    @abstractmethod
+    def provision(self) -> Any:
         """Provision resources required for the deployment."""
-        raise NotImplementedError
+        pass
 
-    def deprovision(self) -> None:
+    @abstractmethod
+    def deprovision(self) -> Any:
         """Destroy the provisioned resources."""
-        raise NotImplementedError
+        pass

--- a/tests/test_runners/test_base_runner.py
+++ b/tests/test_runners/test_base_runner.py
@@ -168,17 +168,3 @@ def test_destroy_terraform(capsys: SysCapture):
             str(exc_info.value)
             == "Terraform failed because of the following error: 'Destroy failed'."
         )
-
-
-def test_provision():
-    """Test provision function in BaseRunner class raises NotImplemented exception."""
-    template_runner = BaseRunner()
-    with pytest.raises(NotImplementedError):
-        template_runner.provision()
-
-
-def test_deprovision():
-    """Test deprovision function in BaseRunner class raises NotImplemented exception."""
-    template_runner = BaseRunner()
-    with pytest.raises(NotImplementedError):
-        template_runner.deprovision()


### PR DESCRIPTION
Remove import of MatchaStateService, make provision and deprovision in BaseRunner abstract methods.

## Checklist

Please ensure you have done the following:

* [x] I have read the [CONTRIBUTING](https://github.com/fuzzylabs/matcha/blob/main/CONTRIBUTING.md) guide.
* [ ] I have updated the documentation if required.
* [ ] I have added tests which cover my changes.

## Type of change

Tick all those that apply:

* [x] Bug Fix (non-breaking change, fixing an issue)
* [ ] New feature (non-breaking change to add functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Other (add details above)
