### PR TITLE
[RPD-291] Dynamically update provisioning message based on stack type

### DIFF
--- a/src/matcha_ml/cli/cli.py
+++ b/src/matcha_ml/cli/cli.py
@@ -8,7 +8,7 @@ from matcha_ml.cli._validation import (
     prefix_typer_callback,
     region_typer_callback,
 )
-from matcha_ml.cli.constants import RESOURCE_MSG, STATE_RESOURCE_MSG
+from matcha_ml.cli.constants import STACK_RESOURCE_MSG_DICT, STATE_RESOURCE_MSG
 from matcha_ml.cli.ui.print_messages import (
     print_error,
     print_resource_output,
@@ -23,6 +23,7 @@ from matcha_ml.cli.ui.status_message_builders import (
     build_step_success_status,
 )
 from matcha_ml.cli.ui.user_approval_functions import is_user_approved
+from matcha_ml.config import MatchaConfigService
 from matcha_ml.errors import MatchaError, MatchaInputError
 
 app = typer.Typer(no_args_is_help=True, pretty_exceptions_show_locals=False)
@@ -110,7 +111,14 @@ def provision(
         Exit: Exit if resources are already provisioned.
     """
     location, prefix, password = fill_provision_variables(location, prefix, password)
-    if is_user_approved(verb="provision", resources=RESOURCE_MSG):
+    stack = MatchaConfigService.get_stack()
+    stack = "default" if stack is None else stack.value.lower()
+
+    if is_user_approved(
+        verb="provision",
+        resources=STACK_RESOURCE_MSG_DICT[stack.upper()],
+        stack_name=stack,
+    ):
         try:
             _ = core.provision(location, prefix, password, verbose)
         except MatchaError as e:
@@ -177,7 +185,14 @@ def destroy() -> None:
     Raises:
         Exit: Exit if core.destroy throws a MatchaError.
     """
-    if is_user_approved(verb="destroy", resources=RESOURCE_MSG + STATE_RESOURCE_MSG):
+    stack = MatchaConfigService.get_stack()
+    stack = "default" if stack is None else stack.value.lower()
+
+    if is_user_approved(
+        verb="destroy",
+        resources=STACK_RESOURCE_MSG_DICT[stack.upper()] + STATE_RESOURCE_MSG,
+        stack_name=stack,
+    ):
         try:
             core.destroy()
             print_status(build_step_success_status("Destroying resources is complete!"))

--- a/src/matcha_ml/cli/constants.py
+++ b/src/matcha_ml/cli/constants.py
@@ -21,6 +21,13 @@ STATE_RESOURCE_MSG = [
     ("Matcha State Container", "A storage container for tracking matcha state"),
 ]
 
+LLM_STACK_RESOURCES = [("ChromaDB", "A vector database for document retrieval")]
+
+STACK_RESOURCE_MSG_DICT = {
+    "DEFAULT": RESOURCE_MSG,
+    "LLM": RESOURCE_MSG + LLM_STACK_RESOURCES,
+}
+
 INFRA_FACTS = [
     "Did you know that Matcha tea was created by accident?",
     "The brewing temperature of the water affects the taste of Matcha",

--- a/src/matcha_ml/cli/ui/user_approval_functions.py
+++ b/src/matcha_ml/cli/ui/user_approval_functions.py
@@ -12,18 +12,21 @@ from matcha_ml.cli.ui.status_message_builders import (
 )
 
 
-def is_user_approved(verb: str, resources: List[Tuple[str, str]]) -> bool:
+def is_user_approved(
+    verb: str, resources: List[Tuple[str, str]], stack_name: str
+) -> bool:
     """Get approval from user within the CLI.
 
     Args:
         verb (str): the verb to use in the approval message.
         resources(list): the list of resources to be actioned by the verb to be provided to the user as a status message
+        stack_name (str): the name of the stack being provisioned.
 
     Returns:
         bool: True if user approves, False otherwise.
     """
     summary_message = build_resource_confirmation(
-        header=f"The following resources will be {verb}ed",
+        header=f"The following {stack_name}-stack resources will be {verb}ed",
         resources=resources,
         footer=f"{verb.capitalize()}ing the resources may take approximately 20 minutes. May we suggest you grab a cup of {Emojis.MATCHA.value}?",
     )

--- a/src/matcha_ml/runners/base_runner.py
+++ b/src/matcha_ml/runners/base_runner.py
@@ -1,7 +1,8 @@
 """Run terraform templates to provision and deprovision resources."""
 import os
+from abc import abstractmethod
 from multiprocessing.pool import ThreadPool
-from typing import Optional, Tuple
+from typing import Any, Optional
 
 import typer
 
@@ -18,7 +19,6 @@ from matcha_ml.services.terraform_service import (
     TerraformConfig,
     TerraformService,
 )
-from matcha_ml.state.matcha_state import MatchaStateService
 
 SPINNER = "dots"
 
@@ -183,10 +183,12 @@ class BaseRunner:
             if tf_result.return_code != 0:
                 raise MatchaTerraformError(tf_error=tf_result.std_err)
 
-    def provision(self) -> MatchaStateService:
+    @abstractmethod
+    def provision(self) -> Any:
         """Provision resources required for the deployment."""
-        raise NotImplementedError
+        pass
 
-    def deprovision(self) -> None:
+    @abstractmethod
+    def deprovision(self) -> Any:
         """Destroy the provisioned resources."""
-        raise NotImplementedError
+        pass

--- a/tests/test_cli/test_provision.py
+++ b/tests/test_cli/test_provision.py
@@ -379,3 +379,25 @@ def test_cli_provision_command_with_password_mismatch(
     assert "Error: The two entered values do not match." in result.stdout
 
     mock_use_lock.assert_not_called()
+
+
+def test_cli_stack_message_on_provision_llm(
+    runner: CliRunner, matcha_testing_directory: str
+):
+    """Test that the stack message is updated if one of the predefined stack is chosen.
+
+    Args:
+        runner (CliRunner): typer CLI runner
+        matcha_testing_directory (str): temporary working directory
+    """
+    os.chdir(matcha_testing_directory)
+
+    runner.invoke(app, ["stack", "set", "llm"])
+    result = runner.invoke(
+        app, ["provision"], input="uksouth\nrand\nvalid\ndefault\ndefault\n"
+    )
+
+    assert result.exit_code == 0
+
+    assert "ChromaDB" in result.stdout
+    assert "llm-stack"

--- a/tests/test_cli/test_ui_functions.py
+++ b/tests/test_cli/test_ui_functions.py
@@ -9,11 +9,11 @@ def test_user_approves():
     """Test if is_user_approved behaves as expected where user provides approval."""
     with mock.patch("typer.confirm") as mock_confirm:
         mock_confirm.return_value = True
-        assert is_user_approved("provision", [])
+        assert is_user_approved("provision", [], "default")
 
 
 def test_user_does_not_approves():
     """Test if is_user_approved behaves as expected where user does not provide approval."""
     with mock.patch("typer.confirm") as mock_confirm:
         mock_confirm.return_value = False
-        assert not is_user_approved("provision", [])
+        assert not is_user_approved("provision", [], "default")

--- a/tests/test_runners/test_base_runner.py
+++ b/tests/test_runners/test_base_runner.py
@@ -168,17 +168,3 @@ def test_destroy_terraform(capsys: SysCapture):
             str(exc_info.value)
             == "Terraform failed because of the following error: 'Destroy failed'."
         )
-
-
-def test_provision():
-    """Test provision function in BaseRunner class raises NotImplemented exception."""
-    template_runner = BaseRunner()
-    with pytest.raises(NotImplementedError):
-        template_runner.provision()
-
-
-def test_deprovision():
-    """Test deprovision function in BaseRunner class raises NotImplemented exception."""
-    template_runner = BaseRunner()
-    with pytest.raises(NotImplementedError):
-        template_runner.deprovision()


### PR DESCRIPTION
Update stack message based on the chosen predefined stack type

## Checklist

Please ensure you have done the following:

* [x] I have read the [CONTRIBUTING](https://github.com/fuzzylabs/matcha/blob/main/CONTRIBUTING.md) guide.
* [ ] I have updated the documentation if required.
* [ ] I have added tests which cover my changes.

## Type of change

Tick all those that apply:

* [x] Bug Fix (non-breaking change, fixing an issue)
* [x] New feature (non-breaking change to add functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Other (add details above)
