### PR TITLE
[RPD-310] Update MatchaConfig and MatchaConfigComponent to include adding and removal of properties without overwriting

### DIFF
--- a/src/matcha_ml/config/matcha_config.py
+++ b/src/matcha_ml/config/matcha_config.py
@@ -45,12 +45,17 @@ class MatchaConfigComponent:
             None,
         )
 
-        # if property is None:
-        #     raise MatchaError(
-        #         f"The property with the name '{property_name}' could not be found."
-        #     )
-
         return property
+
+    def remove_property(self, property_name: str) -> None:
+        """Removes a property by name if it exists in the component.
+
+        Args:
+            property_name (str): the name of the property to remove.
+        """
+        self.properties = [
+            item for item in self.properties if item.name != property_name
+        ]
 
 
 @dataclass
@@ -206,6 +211,47 @@ class MatchaConfigService:
             config = MatchaConfig(components)
 
         MatchaConfigService.write_matcha_config(config)
+
+    @staticmethod
+    def add_property(
+        component_name: str, component_property: MatchaConfigComponentProperty
+    ) -> None:
+        """Method to add a MatchaConfigComponentProperty to a Component, if it does not exist, this will create the component too.
+
+        Args:
+            component_name (str): Name of the component.
+            component_property (MatchaConfigComponentProperty): Property to add to the component.
+        """
+        if MatchaConfigService.config_file_exists():
+            config = MatchaConfigService.read_matcha_config()
+            component = config.find_component(component_name)
+            if component is not None:
+                component.properties.append(component_property)
+                MatchaConfigService.update(component)
+                return
+
+        MatchaConfigService.update(
+            MatchaConfigComponent(component_name, [component_property])
+        )
+
+    @staticmethod
+    def remove_property(component_name: str, property_name: str) -> None:
+        """Method to remove a MatchaConfigComponentProperty to a Component, if it does not exist, this will create the component too.
+
+        Args:
+            component_name (str): Name of the component.
+            property_name (str): Name of the property within the component.
+        """
+        if MatchaConfigService.config_file_exists():
+            config = MatchaConfigService.read_matcha_config()
+            component = config.find_component(component_name)
+            if component is not None:
+                component.remove_property(property_name)
+                MatchaConfigService.update(component)
+            else:
+                raise MatchaError(f"Error - The {component_name} does not exist.")
+        else:
+            raise MatchaError("Error - The Matcha config file does not exist.")
 
     @staticmethod
     def delete_matcha_config() -> None:

--- a/src/matcha_ml/config/matcha_config.py
+++ b/src/matcha_ml/config/matcha_config.py
@@ -241,6 +241,10 @@ class MatchaConfigService:
         Args:
             component_name (str): Name of the component.
             property_name (str): Name of the property within the component.
+
+        Raises:
+            MatchaError: raises a MatchaError if the local config file does not exist.
+            MatchaError: raises a MatchaError if the specified component does not exist.
         """
         if MatchaConfigService.config_file_exists():
             config = MatchaConfigService.read_matcha_config()

--- a/src/matcha_ml/config/matcha_config.py
+++ b/src/matcha_ml/config/matcha_config.py
@@ -236,7 +236,7 @@ class MatchaConfigService:
 
     @staticmethod
     def remove_property(component_name: str, property_name: str) -> None:
-        """Method to remove a MatchaConfigComponentProperty to a Component, if it does not exist, this will create the component too.
+        """Method to remove a MatchaConfigComponentProperty to a Component.
 
         Args:
             component_name (str): Name of the component.

--- a/tests/test_config/test_matcha_config.py
+++ b/tests/test_config/test_matcha_config.py
@@ -282,3 +282,66 @@ def test_remove_property_expected(
             MatchaConfigComponentProperty(name="container_name", value="test-container")
         ],
     )
+
+
+def test_add_property_expected(
+    matcha_testing_directory, mocked_matcha_config_json_object
+):
+    """Test adding a property.
+
+    Args:
+        matcha_testing_directory (str): A temporary working directory.
+        mocked_matcha_config_json_object (dict): A dictionary representation of a matcha config json file.
+    """
+    os.chdir(matcha_testing_directory)
+    config = MatchaConfig.from_dict(mocked_matcha_config_json_object)
+    config_dict = config.to_dict()
+
+    MatchaConfigService.write_matcha_config(config)
+
+    component_property = MatchaConfigComponentProperty(name="name", value="passed")
+    second_component_property = MatchaConfigComponentProperty(
+        name="location", value="ukwest"
+    )
+
+    MatchaConfigService.add_property(
+        component_name="test", component_property=component_property
+    )
+    MatchaConfigService.add_property(
+        component_name="test", component_property=second_component_property
+    )
+
+    updated_config = MatchaConfigService.read_matcha_config()
+    updated_config_dict = updated_config.to_dict()
+
+    assert len(updated_config_dict) - 1 == len(config_dict)
+    assert config_dict.items() <= updated_config_dict.items()
+    assert updated_config_dict["test"]["name"] == "passed"
+    assert updated_config_dict["test"]["location"] == "ukwest"
+
+
+def test_remove_property_config_service_expected(
+    matcha_testing_directory, mocked_matcha_config_json_object
+):
+    """Test removing a property from the ConfigService level.
+
+    Args:
+        matcha_testing_directory (str): A temporary working directory.
+        mocked_matcha_config_json_object (dict): A dictionary representation of a matcha config json file.
+    """
+    os.chdir(matcha_testing_directory)
+    config = MatchaConfig.from_dict(mocked_matcha_config_json_object)
+
+    MatchaConfigService.write_matcha_config(config)
+
+    config_dict = MatchaConfigService.read_matcha_config().to_dict()
+    assert config_dict["remote_state_bucket"]["account_name"] == "test-account"
+
+    MatchaConfigService.remove_property(
+        component_name="remote_state_bucket", property_name="account_name"
+    )
+
+    updated_config = MatchaConfigService.read_matcha_config()
+    updated_config_dict = updated_config.to_dict()
+
+    assert updated_config_dict.get("remote_state_bucket").get("account_name") is None

--- a/tests/test_config/test_matcha_config.py
+++ b/tests/test_config/test_matcha_config.py
@@ -260,3 +260,25 @@ def test_matcha_config_service_update(
     assert config_dict.items() <= updated_config_dict.items()
     assert updated_config_dict["test"]["name"] == "passed"
     assert updated_config_dict["test2"]["name"] == "passed_again"
+
+
+def test_remove_property_expected(
+    mocked_matcha_config_component: MatchaConfigComponent,
+):
+    """Test that a component is removed if it exists.
+
+    Args:
+        mocked_matcha_config_component (MatchaConfigComponent): a mocked MatchaConfigComponent instance.
+    """
+    mocked_matcha_config_component.remove_property(property_name="account_name")
+    mocked_matcha_config_component.remove_property(property_name="resource_group_name")
+    mocked_matcha_config_component.remove_property(
+        property_name="not_an_existing_property_name"
+    )
+
+    assert mocked_matcha_config_component == MatchaConfigComponent(
+        name="remote_state_bucket",
+        properties=[
+            MatchaConfigComponentProperty(name="container_name", value="test-container")
+        ],
+    )


### PR DESCRIPTION
MatchaConfig and MatchaConfigComponent need additional functions:
`MatchaConfigComponent`:


```
    def remove_property(self, property_name: str) -> None:
MatchaConfigService
```

```
    @staticmethod
    def add_property(
        component_name: str, component_property: MatchaConfigComponentProperty
    ) -> None:
```

and 


```
    @staticmethod
    def remove_property(
        component_name: str, property_name: str
    ) -> None:
```

## Checklist

Please ensure you have done the following:

* [x] I have read the [CONTRIBUTING](https://github.com/fuzzylabs/matcha/blob/main/CONTRIBUTING.md) guide.
* [x] I have updated the documentation if required.
* [x] I have added tests which cover my changes.

## Type of change

Tick all those that apply:

* [ ] Bug Fix (non-breaking change, fixing an issue)
* [x] New feature (non-breaking change to add functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Other (add details above)
