### PR TITLE
[RPD-312] Update base_template/azure_template files to handle new modular Terraform files

### DIFF
--- a/src/matcha_ml/core/core.py
+++ b/src/matcha_ml/core/core.py
@@ -311,7 +311,7 @@ def provision(
             os.path.dirname(__file__),
             os.pardir,
             "infrastructure",
-            stack_name,
+            "modules",
         )
 
         azure_template = AzureTemplate(

--- a/src/matcha_ml/templates/azure_template.py
+++ b/src/matcha_ml/templates/azure_template.py
@@ -66,8 +66,8 @@ class AzureTemplate(BaseTemplate):
                     os.remove(item_path)
                 elif os.path.isdir(item_path) and item not in except_files:
                     shutil.rmtree(item_path)
-        except Exception as e:
-            print("Error:", e)
+        except (OSError, FileNotFoundError) as e:
+            print(f"Error while emptying directory '{directory}': {e}")
 
     @staticmethod
     def concatenate_files(source_file: str, target_file: str) -> None:
@@ -80,10 +80,11 @@ class AzureTemplate(BaseTemplate):
         try:
             with open(source_file) as source, open(target_file, "a") as target:
                 target.write(source.read())
-        except Exception as e:
-            print("Error:", e)
+        except (OSError, FileNotFoundError) as e:
+            print(f"Error while concatenating files: {e}")
 
-    def recursively_copy_files(self, source_dir: str, target_dir: str) -> None:
+    @staticmethod
+    def recursively_copy_files(source_dir: str, target_dir: str) -> None:
         """Copy all files within a source location to a target location.
 
         Args:
@@ -102,11 +103,11 @@ class AzureTemplate(BaseTemplate):
                     shutil.copytree(source_item, target_item)
                 elif os.path.exists(target_item):
                     # Concatenate the source file content to the target file
-                    self.concatenate_files(source_item, target_item)
+                    AzureTemplate.concatenate_files(source_item, target_item)
                 else:
                     shutil.copy2(source_item, target_item)
-        except Exception as e:
-            print("Error:", e)
+        except (OSError, FileNotFoundError) as e:
+            print(f"Error while copying files: {e}")
 
     def build_template(
         self,

--- a/src/matcha_ml/templates/azure_template.py
+++ b/src/matcha_ml/templates/azure_template.py
@@ -5,7 +5,7 @@ import shutil
 from shutil import rmtree
 from typing import List, Optional
 
-from matcha_ml.cli.ui.print_messages import print_status
+from matcha_ml.cli.ui.print_messages import print_error, print_status
 from matcha_ml.cli.ui.status_message_builders import (
     build_status,
     build_step_success_status,
@@ -67,7 +67,7 @@ class AzureTemplate(BaseTemplate):
                 elif os.path.isdir(item_path) and item not in except_files:
                     shutil.rmtree(item_path)
         except (OSError, FileNotFoundError) as e:
-            print(f"Error while emptying directory '{directory}': {e}")
+            print_error(f"Error while emptying directory '{directory}': {e}")
 
     @staticmethod
     def concatenate_files(source_file: str, target_file: str) -> None:
@@ -81,7 +81,7 @@ class AzureTemplate(BaseTemplate):
             with open(source_file) as source, open(target_file, "a") as target:
                 target.write(source.read())
         except (OSError, FileNotFoundError) as e:
-            print(f"Error while concatenating files: {e}")
+            print_error(f"Error while concatenating files: {e}")
 
     @staticmethod
     def recursively_copy_files(source_dir: str, target_dir: str) -> None:
@@ -107,7 +107,7 @@ class AzureTemplate(BaseTemplate):
                 else:
                     shutil.copy2(source_item, target_item)
         except (OSError, FileNotFoundError) as e:
-            print(f"Error while copying files: {e}")
+            print_error(f"Error while copying files: {e}")
 
     def build_template(
         self,

--- a/src/matcha_ml/templates/azure_template.py
+++ b/src/matcha_ml/templates/azure_template.py
@@ -1,6 +1,18 @@
 """Build a template for provisioning resources on Azure using terraform files."""
+import json
+import os
+import shutil
+from shutil import rmtree
 from typing import List, Optional
 
+from matcha_ml.cli.ui.print_messages import print_status
+from matcha_ml.cli.ui.status_message_builders import (
+    build_status,
+    build_step_success_status,
+    build_substep_success_status,
+)
+from matcha_ml.config.matcha_config import MatchaConfigService
+from matcha_ml.errors import MatchaPermissionError
 from matcha_ml.state import MatchaState, MatchaStateService
 from matcha_ml.templates.base_template import BaseTemplate, TemplateVariables
 
@@ -39,6 +51,63 @@ class AzureTemplate(BaseTemplate):
         """
         super().__init__(submodule_names)
 
+    @staticmethod
+    def empty_directory_except_files(directory: str, except_files: List[str]) -> None:
+        """Empties a directory of all files and folders except for a list of file names.
+
+        Args:
+            directory (str): Directory name to clean.
+            except_files (List[str]): List of file names to be excluded from removal.
+        """
+        try:
+            for item in os.listdir(directory):
+                item_path = os.path.join(directory, item)
+                if os.path.isfile(item_path) and item not in except_files:
+                    os.remove(item_path)
+                elif os.path.isdir(item_path) and item not in except_files:
+                    shutil.rmtree(item_path)
+        except Exception as e:
+            print("Error:", e)
+
+    @staticmethod
+    def concatenate_files(source_file: str, target_file: str) -> None:
+        """Takes the contents of one file and concatenates it to a target file.
+
+        Args:
+            source_file (str): File to copy contents from.
+            target_file (str): Destination to add source file contents to.
+        """
+        try:
+            with open(source_file) as source, open(target_file, "a") as target:
+                target.write(source.read())
+        except Exception as e:
+            print("Error:", e)
+
+    def recursively_copy_files(self, source_dir: str, target_dir: str) -> None:
+        """Copy all files within a source location to a target location.
+
+        Args:
+            source_dir (str): The source directory containing files to copy.
+            target_dir (str): The target directory to copy files to.
+        """
+        try:
+            if not os.path.exists(target_dir):
+                os.makedirs(target_dir)
+
+            for item in os.listdir(source_dir):
+                source_item = os.path.join(source_dir, item)
+                target_item = os.path.join(target_dir, item)
+
+                if os.path.isdir(source_item):
+                    shutil.copytree(source_item, target_item)
+                elif os.path.exists(target_item):
+                    # Concatenate the source file content to the target file
+                    self.concatenate_files(source_item, target_item)
+                else:
+                    shutil.copy2(source_item, target_item)
+        except Exception as e:
+            print("Error:", e)
+
     def build_template(
         self,
         config: TemplateVariables,
@@ -46,15 +115,89 @@ class AzureTemplate(BaseTemplate):
         destination: str,
         verbose: Optional[bool] = False,
     ) -> None:
-        """Builds a template using the provided configuration and copies it to the destination.
+        """Build and copy the template to the project directory.
 
         Args:
             config (TemplateVariables): variables to apply to the template.
             template_src (str): path of the template to use.
             destination (str): destination path to write template to.
-            verbose (Optional[bool]): additional output is shown when True. Defaults to False.
+            verbose (bool, optional): additional output is shown when True. Defaults to False.
+
+        Raises:
+            MatchaPermissionError: when there are no write permissions on the configuration destination
         """
-        super().build_template(config, template_src, destination, verbose)
+        try:
+            print_status(build_status("\nBuilding configuration template..."))
+
+            # Override configuration if it already exists
+            if os.path.exists(destination):
+                rmtree(destination)
+
+            os.makedirs(destination, exist_ok=True)
+
+            if verbose:
+                print_status(
+                    build_substep_success_status(
+                        f"Ensure template destination directory: {destination}"
+                    )
+                )
+
+            stack = {"common"}
+            stack_component = MatchaConfigService.read_matcha_config().find_component(
+                "stack"
+            )
+            if stack_component is not None:
+                for item in stack_component.properties:
+                    if item.name != "name":
+                        stack.add(item.value)
+
+            self.empty_directory_except_files(
+                destination, [".terraform", ".terraform.lock.hcl", "terraform.tfstate"]
+            )
+            for module in stack:
+                source_directory = os.path.join(template_src, f"{module}")
+                self.recursively_copy_files(source_directory, destination)
+
+                if verbose:
+                    print_status(
+                        build_substep_success_status(
+                            f"{module} module configuration was copied"
+                        )
+                    )
+
+            if verbose:
+                print_status(
+                    build_substep_success_status("Configurations were copied.")
+                )
+
+            configuration_destination = os.path.join(
+                destination, "terraform.tfvars.json"
+            )
+            with open(configuration_destination, "w") as f:
+                json.dump(vars(config), f)
+
+            if verbose:
+                print_status(
+                    build_substep_success_status("Template variables were added.")
+                )
+
+        except PermissionError:
+            raise MatchaPermissionError(
+                f"Error - You do not have permission to write the configuration. Check if you have write permissions for '{destination}'."
+            )
+
+        if verbose:
+            print_status(
+                build_substep_success_status("Template configuration has finished!")
+            )
+
+        print_status(
+            build_step_success_status(
+                f"The configuration template was written to {destination}"
+            )
+        )
+
+        print()
 
         # Add matcha.state file one directory above the template
         config_dict = vars(config)

--- a/tests/test_templates/test_azure_template.py
+++ b/tests/test_templates/test_azure_template.py
@@ -1,4 +1,8 @@
 """Test suite to test the azure template."""
+import os
+import shutil
+import tempfile
+
 import pytest
 
 from matcha_ml.templates import AzureTemplate
@@ -12,3 +16,206 @@ def azure_template() -> AzureTemplate:
         AzureTemplate: the Azure template.
     """
     return AzureTemplate()
+
+
+@pytest.fixture
+def temp_directory() -> str:
+    """Temporary testing directory.
+
+    Returns:
+        str: Location of the directory.
+
+    Yields:
+        Iterator[str]: Location of the directory.
+    """
+    temp_dir = tempfile.mkdtemp()
+    yield temp_dir
+    shutil.rmtree(temp_dir)
+
+
+def test_empty_directory_except_files(temp_directory: str) -> None:
+    """Test the 'empty_directory_except_files' function.
+
+    Args:
+        temp_directory (str): Temporary directory path for testing.
+    """
+    # Create some files and directories in the temporary directory
+    with open(os.path.join(temp_directory, "file1.txt"), "w") as f:
+        f.write("Content of file1")
+    with open(os.path.join(temp_directory, "file2.txt"), "w") as f:
+        f.write("Content of file2")
+
+    # Call the function to empty the directory except for file2.txt
+    AzureTemplate.empty_directory_except_files(
+        temp_directory, except_files=["file2.txt"]
+    )
+
+    assert not os.path.exists(os.path.join(temp_directory, "file1.txt"))
+    assert os.path.exists(os.path.join(temp_directory, "file2.txt"))
+
+
+def test_concatenate_files(temp_directory: str) -> None:
+    """Test the 'concatenate_files' function.
+
+    Args:
+        temp_directory (str): Temporary directory path for testing.
+    """
+    source_file = os.path.join(temp_directory, "source.txt")
+    target_file = os.path.join(temp_directory, "target.txt")
+
+    # Create source and target files with some content
+    with open(source_file, "w") as source:
+        source.write("Source file content")
+    with open(target_file, "w") as target:
+        target.write("Target file content")
+
+    # Call the function to concatenate source_file to target_file
+    AzureTemplate.concatenate_files(source_file, target_file)
+
+    # Check if the contents of target_file have been updated
+    with open(target_file) as target:
+        assert target.read() == "Target file contentSource file content"
+
+
+def test_recursively_copy_files(temp_directory: str) -> None:
+    """Test the 'recursively_copy_files' function.
+
+    Args:
+        temp_directory (str): Temporary directory path for testing.
+    """
+    source_dir = os.path.join(temp_directory, "source")
+    target_dir = os.path.join(temp_directory, "target")
+
+    # Create some files and directories in the source directory
+    os.mkdir(source_dir)
+    os.mkdir(os.path.join(source_dir, "subfolder"))
+    with open(os.path.join(source_dir, "file1.txt"), "w") as f:
+        f.write("Content of file1")
+    with open(os.path.join(source_dir, "subfolder", "file2.txt"), "w") as f:
+        f.write("Content of file2")
+
+    # Call the function to copy files from source_dir to target_dir
+    AzureTemplate.recursively_copy_files(source_dir, target_dir)
+
+    # Check if the files and directories have been copied correctly
+    assert os.path.exists(os.path.join(target_dir, "file1.txt"))
+    assert os.path.exists(os.path.join(target_dir, "subfolder", "file2.txt"))
+
+    # Check if the content of 'file1.txt' and 'file2.txt' has been copied correctly
+    with open(os.path.join(target_dir, "file1.txt")) as f:
+        assert f.read() == "Content of file1"
+    with open(os.path.join(target_dir, "subfolder", "file2.txt")) as f:
+        assert f.read() == "Content of file2"
+
+
+def test_empty_directory_except_files_error_handling(
+    temp_directory: str, capsys
+) -> None:
+    """Test error handling in AzureTemplate.empty_directory_except_files function.
+
+    Args:
+        temp_directory (str): The path to a temporary directory.
+        capsys: Pytest fixture for capturing stdout and stderr.
+    """
+    # Run the function that raises an exception
+    AzureTemplate.empty_directory_except_files("nonexistent_directory", [])
+
+    # Capture the output (stdout and stderr)
+    captured = capsys.readouterr()
+
+    # Check if the error message is present in the captured output
+    assert "Error while emptying directory" in captured.out
+
+
+def test_concatenate_files_error_handling(temp_directory: str, capsys) -> None:
+    """Test error handling in AzureTemplate.concatenate_files function.
+
+    Args:
+        temp_directory (str): The path to a temporary directory.
+        capsys: Pytest fixture for capturing stdout and stderr.
+    """
+    os.path.join(temp_directory, "source.txt")
+    target_file = os.path.join(temp_directory, "target.txt")
+
+    # Run the function that raises an exception
+    AzureTemplate.concatenate_files("nonexistent_file.txt", target_file)
+
+    # Capture the output (stdout and stderr)
+    captured = capsys.readouterr()
+
+    # Check if the error message is present in the captured output
+    assert "Error while concatenating files:" in captured.out
+
+
+def test_recursively_copy_files_error_handling_directory_not_exist(
+    temp_directory: str, capsys
+) -> None:
+    """Test error handling in AzureTemplate.recursively_copy_files function when source directory does not exist.
+
+    Args:
+        temp_directory (str): The path to a temporary directory.
+        capsys: Pytest fixture for capturing stdout and stderr.
+    """
+    # Run the function that raises an exception
+    AzureTemplate.recursively_copy_files("nonexistent_source", "target")
+
+    # Capture the output (stdout and stderr)
+    captured = capsys.readouterr()
+
+    # Check if the error message is present in the captured output
+    assert (
+        "Error while copying files: [Errno 2] No such file or directory: 'nonexistent_source'"
+        in captured.out
+    )
+
+
+def test_recursively_copy_files_error_handling_target_dir_exists(
+    temp_directory: str, capsys
+) -> None:
+    """Test error handling in AzureTemplate.recursively_copy_files function when the target directory cannot be created.
+
+    Args:
+        temp_directory (str): The path to a temporary directory.
+        capsys: Pytest fixture for capturing stdout and stderr.
+    """
+    # Create a file with the same name as the target directory
+    target_dir_as_file = os.path.join(temp_directory, "target")
+    with open(target_dir_as_file, "w") as file:
+        file.write("content")
+
+    # Run the function that raises an exception
+    AzureTemplate.recursively_copy_files(temp_directory, target_dir_as_file)
+
+    # Capture the output (stdout and stderr)
+    captured = capsys.readouterr()
+
+    # Check if the error message is present in the captured output
+    assert "Error while copying files:" in captured.out
+
+
+def test_recursively_copy_files_error_handling_permission_error(
+    temp_directory: str, capsys
+) -> None:
+    """Test error handling in AzureTemplate.recursively_copy_files function when a source file cannot be copied due to permission error.
+
+    Args:
+        temp_directory (str): The path to a temporary directory.
+        capsys: Pytest fixture for capturing stdout and stderr.
+    """
+    source_file = os.path.join(temp_directory, "source.txt")
+    with open(source_file, "w") as file:
+        file.write("content")
+
+    # Create a read-only target directory
+    target_dir = os.path.join(temp_directory, "target")
+    os.makedirs(target_dir, exist_ok=True)
+    os.chmod(target_dir, 0o444)  # Make it read-only
+
+    # Run the function that raises an exception
+    AzureTemplate.recursively_copy_files(temp_directory, target_dir)
+
+    # Capture the output (stdout and stderr)
+    captured = capsys.readouterr()
+
+    # Check if the error message is present in the captured output
+    assert "Permission denied" in captured.out

--- a/tests/test_templates/test_azure_template.py
+++ b/tests/test_templates/test_azure_template.py
@@ -124,7 +124,7 @@ def test_empty_directory_except_files_error_handling(
     captured = capsys.readouterr()
 
     # Check if the error message is present in the captured output
-    assert "Error while emptying directory" in captured.out
+    assert "Error while emptying directory" in captured.err
 
 
 def test_concatenate_files_error_handling(temp_directory: str, capsys) -> None:
@@ -144,7 +144,7 @@ def test_concatenate_files_error_handling(temp_directory: str, capsys) -> None:
     captured = capsys.readouterr()
 
     # Check if the error message is present in the captured output
-    assert "Error while concatenating files:" in captured.out
+    assert "Error while concatenating files:" in captured.err
 
 
 def test_recursively_copy_files_error_handling_directory_not_exist(
@@ -164,8 +164,8 @@ def test_recursively_copy_files_error_handling_directory_not_exist(
 
     # Check if the error message is present in the captured output
     assert (
-        "Error while copying files: [Errno 2] No such file or directory: 'nonexistent_source'"
-        in captured.out
+        "Error while copying files: [Errno 2] No such file or directory:"
+        in captured.err
     )
 
 
@@ -190,7 +190,7 @@ def test_recursively_copy_files_error_handling_target_dir_exists(
     captured = capsys.readouterr()
 
     # Check if the error message is present in the captured output
-    assert "Error while copying files:" in captured.out
+    assert "Error while copying files:" in captured.err
 
 
 def test_recursively_copy_files_error_handling_permission_error(
@@ -218,4 +218,4 @@ def test_recursively_copy_files_error_handling_permission_error(
     captured = capsys.readouterr()
 
     # Check if the error message is present in the captured output
-    assert "Permission denied" in captured.out
+    assert "Permission denied" in captured.err


### PR DESCRIPTION
This PR adds the functionality for using the modular implementation of Matcha. It mainly updates the `copy_file` function within AzureTemplate class to recursively copy and concatenate Terraform files from the modules to the target destination.

This allows users to add modules to their stack to make a custom stack and provision only the required modules.
```
{"stack": {"name": "custom", "experiment_tracker": "mlflow", "orchestrator": "zenml", "deployer": "seldon", "vector_database": "chroma"}}
```

## Checklist

Please ensure you have done the following:

* [x] I have read the [CONTRIBUTING](https://github.com/fuzzylabs/matcha/blob/main/CONTRIBUTING.md) guide.
* [x] I have updated the documentation if required.
* [x] I have added tests which cover my changes.

## Type of change

Tick all those that apply:

* [ ] Bug Fix (non-breaking change, fixing an issue)
* [x] New feature (non-breaking change to add functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Other (add details above)
