### PR TITLE
[RPD-309] Update stack set to add individual modules to the `matcha.config.json` file

### DIFF
--- a/src/matcha_ml/constants.py
+++ b/src/matcha_ml/constants.py
@@ -19,3 +19,12 @@ STACK_MODULES = {
     },
     "deployer": {"seldon": MatchaConfigComponentProperty("deployer", "seldon")},
 }
+
+DEFAULT_STACK = [
+    MatchaConfigComponentProperty("orchestrator", "zenml"),
+    MatchaConfigComponentProperty("experiment_tracker", "mlflow"),
+    MatchaConfigComponentProperty("data_version_control", "dvc"),
+    MatchaConfigComponentProperty("deployer", "seldon"),
+]
+
+LLM_STACK = DEFAULT_STACK + [MatchaConfigComponentProperty("vector_database", "chroma")]

--- a/src/matcha_ml/templates/azure_template.py
+++ b/src/matcha_ml/templates/azure_template.py
@@ -4,7 +4,7 @@ from typing import List, Optional
 from matcha_ml.state import MatchaState, MatchaStateService
 from matcha_ml.templates.base_template import BaseTemplate, TemplateVariables
 
-DEFAULT_STACK = [
+DEFAULT_STACK_TF = [
     "aks",
     "resource_group",
     "mlflow_module",
@@ -17,7 +17,7 @@ DEFAULT_STACK = [
     "zen_server/zenml_helm/templates",
     "data_version_control_storage",
 ]
-LLM_STACK = DEFAULT_STACK + [
+LLM_STACK_TF = DEFAULT_STACK_TF + [
     "chroma",
     "chroma/chroma_helm",
     "chroma/chroma_helm/templates",

--- a/tests/test_cli/test_provision.py
+++ b/tests/test_cli/test_provision.py
@@ -9,7 +9,7 @@ import pytest
 from typer.testing import CliRunner
 
 from matcha_ml.cli.cli import app
-from matcha_ml.templates.azure_template import DEFAULT_STACK
+from matcha_ml.templates.azure_template import DEFAULT_STACK_TF
 
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 TEMPLATE_DIR = os.path.join(
@@ -66,7 +66,7 @@ def assert_infrastructure(
         module_file_path = os.path.join(destination_path, module_file_name)
         assert os.path.exists(module_file_path)
 
-    for module_name in DEFAULT_STACK:
+    for module_name in DEFAULT_STACK_TF:
         for module_file_name in glob.glob(
             os.path.join(TEMPLATE_DIR, module_name, "*.tf")
         ):

--- a/tests/test_cli/test_stack.py
+++ b/tests/test_cli/test_stack.py
@@ -125,7 +125,17 @@ def test_stack_set_file_created(
     assert result.exit_code == 0
 
     config = MatchaConfigService.read_matcha_config()
-    assert config.to_dict() == {"stack": {"name": "llm"}}
+    expected_stack = {
+        "stack": {
+            "name": "llm",
+            "orchestrator": "zenml",
+            "experiment_tracker": "mlflow",
+            "data_version_control": "dvc",
+            "deployer": "seldon",
+            "vector_database": "chroma",
+        }
+    }
+    assert config.to_dict() == expected_stack
 
 
 def test_stack_set_file_modified(

--- a/tests/test_core/test_core_provision.py
+++ b/tests/test_core/test_core_provision.py
@@ -23,7 +23,7 @@ from matcha_ml.services.global_parameters_service import GlobalParameters
 from matcha_ml.state.matcha_state import (
     MatchaState,
 )
-from matcha_ml.templates.azure_template import DEFAULT_STACK
+from matcha_ml.templates.azure_template import DEFAULT_STACK_TF
 
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 
@@ -154,7 +154,7 @@ def assert_infrastructure(
         module_file_path = os.path.join(destination_path, module_file_name)
         assert os.path.exists(module_file_path)
 
-    for module_name in DEFAULT_STACK:
+    for module_name in DEFAULT_STACK_TF:
         for module_file_name in glob.glob(
             os.path.join(TEMPLATE_DIR, module_name, "*.tf")
         ):
@@ -329,7 +329,13 @@ def test_stale_remote_state_file_is_removed(matcha_testing_directory: str):
             "container_name": "test-container",
             "resource_group_name": "test-rg",
         },
-        "stack": {"name": "default"},
+        "stack": {
+            "name": "default",
+            "orchestrator": "zenml",
+            "experiment_tracker": "mlflow",
+            "data_version_control": "dvc",
+            "deployer": "seldon",
+        },
     }
 
     with mock.patch(


### PR DESCRIPTION
This PR updates the `stack_set` function such that the components of the respective stacks (`default` and `llm`) are included in the `matcha.config.json`. 

To do this, the PR introduces two constants: `DEFAULT_STACK` and `LLM_STACK`. The contents of these constants are then added to `MatchaConfigComponent`, along with the name. The tests have been refactored to reflect this change.

I have also updated the name of the original `DEFAULT_STACK` and `LLM_STACK` in `matcha_ml.templates.azure_template` to `DEFAULT_STACK_TF` and `LLM_STACK_TF` respectively. This is to avoid a naming conflict and the newer constants more actually describe the stack.

## Checklist

Please ensure you have done the following:

* [x] I have read the [CONTRIBUTING](https://github.com/fuzzylabs/matcha/blob/main/CONTRIBUTING.md) guide.
* [ ] I have updated the documentation if required.
* [x] I have added tests which cover my changes.

## Type of change

Tick all those that apply:

* [ ] Bug Fix (non-breaking change, fixing an issue)
* [x] New feature (non-breaking change to add functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Other (add details above)
