### PR TITLE
[RPD-307] add core stack remove command

### DIFF
--- a/src/matcha_ml/cli/cli.py
+++ b/src/matcha_ml/cli/cli.py
@@ -251,7 +251,7 @@ def opt_in() -> None:
 
 
 @stack_app.command(help="Define the stack for Matcha to provision.")
-def set(stack: str = typer.Argument("default")) -> None:
+def set(stack: Annotated[str, typer.Argument("default")]) -> None:
     """Define the stack for Matcha to provision.
 
     Args:

--- a/src/matcha_ml/cli/cli.py
+++ b/src/matcha_ml/cli/cli.py
@@ -23,7 +23,7 @@ from matcha_ml.cli.ui.status_message_builders import (
     build_step_success_status,
 )
 from matcha_ml.cli.ui.user_approval_functions import is_user_approved
-from matcha_ml.core.core import stack_add, stack_remove
+from matcha_ml.core.core import stack_remove
 from matcha_ml.errors import MatchaError, MatchaInputError
 
 app = typer.Typer(no_args_is_help=True, pretty_exceptions_show_locals=False)
@@ -264,34 +264,6 @@ def set(stack: str = typer.Argument("default")) -> None:
         raise typer.Exit()
     except MatchaError as e:
         print_error(str(e))
-        raise typer.Exit()
-
-
-@stack_app.command(help="Add a module to the stack.")
-def add(module: str = typer.Argument(None)) -> None:
-    """Add a module to the stack for Matcha to provision.
-
-    Args:
-        module (str): the name of the module to add (e.g. 'seldon').
-    """
-    if module:
-        try:
-            stack_add(module)
-            print_status(
-                build_status(
-                    f"Matcha '{module}' module has been added to the current stack."
-                )
-            )
-        except MatchaInputError as e:
-            print_error(str(e))
-            raise typer.Exit()
-        except MatchaError as e:
-            print_error(str(e))
-            raise typer.Exit()
-    else:
-        print_error(
-            "No module specified. Please run `matcha stack add` again and provide the name of the module you wish to add."
-        )
         raise typer.Exit()
 
 

--- a/src/matcha_ml/cli/cli.py
+++ b/src/matcha_ml/cli/cli.py
@@ -251,7 +251,7 @@ def opt_in() -> None:
 
 
 @stack_app.command(help="Define the stack for Matcha to provision.")
-def set(stack: Annotated[str, typer.Argument("default")]) -> None:
+def set(stack: str = typer.Argument("default")) -> None:
     """Define the stack for Matcha to provision.
 
     Args:

--- a/src/matcha_ml/cli/cli.py
+++ b/src/matcha_ml/cli/cli.py
@@ -270,8 +270,8 @@ def set(stack: str = typer.Argument("default")) -> None:
 
 @stack_app.command(help="Add a module to the stack.")
 def add(
-    module: Annotated[str, typer.Argument(help="The module name.")],
-    flavor: Annotated[str, typer.Argument(help="the flavor of the module.")],
+    module: Annotated[str, typer.Argument(None, help="The module name.")],
+    flavor: Annotated[str, typer.Argument(None, help="The flavor of the module.")],
 ) -> None:
     """Add a module to the stack for Matcha to provision.
 

--- a/src/matcha_ml/cli/cli.py
+++ b/src/matcha_ml/cli/cli.py
@@ -270,8 +270,8 @@ def set(stack: str = typer.Argument("default")) -> None:
 
 @stack_app.command(help="Add a module to the stack.")
 def add(
-    module: Annotated[str, typer.Argument(None, help="The module name.")],
-    flavor: Annotated[str, typer.Argument(None, help="The flavor of the module.")],
+    module: Annotated[str, typer.Argument(help="The module name.")],
+    flavor: Annotated[str, typer.Argument(help="The flavor of the module.")],
 ) -> None:
     """Add a module to the stack for Matcha to provision.
 
@@ -298,7 +298,9 @@ def add(
 
 
 @stack_app.command(help="Remove a module from the current Matcha stack.")
-def remove(module: str = typer.Argument(None)) -> None:
+def remove(
+    module: Annotated[str, typer.Argument(help="The module name.")],
+) -> None:
     """Remove a module from the current Matcha stack.
 
     Args:

--- a/src/matcha_ml/cli/cli.py
+++ b/src/matcha_ml/cli/cli.py
@@ -306,24 +306,18 @@ def remove(
     Args:
         module (str): the name of the module to be removed.
     """
-    if module:
-        try:
-            stack_remove(module)
-            print_status(
-                build_status(
-                    f"Matcha '{module}' module has been removed from the current stack."
-                )
+    try:
+        stack_remove(module)
+        print_status(
+            build_status(
+                f"Matcha '{module}' module has been removed from the current stack."
             )
-        except MatchaInputError as e:
-            print_error(str(e))
-            raise typer.Exit()
-        except MatchaError as e:
-            print_error(str(e))
-            raise typer.Exit()
-    else:
-        print_error(
-            "No module specified. Please run `matcha stack remove` again and provide the name of the module you wish to remove."
         )
+    except MatchaInputError as e:
+        print_error(str(e))
+        raise typer.Exit()
+    except MatchaError as e:
+        print_error(str(e))
         raise typer.Exit()
 
 

--- a/src/matcha_ml/config/matcha_config.py
+++ b/src/matcha_ml/config/matcha_config.py
@@ -236,7 +236,7 @@ class MatchaConfigService:
 
     @staticmethod
     def remove_property(component_name: str, property_name: str) -> None:
-        """Method to remove a MatchaConfigComponentProperty to a Component.
+        """Method to remove a MatchaConfigComponentProperty from a Component.
 
         Args:
             component_name (str): Name of the component.

--- a/src/matcha_ml/core/core.py
+++ b/src/matcha_ml/core/core.py
@@ -441,3 +441,7 @@ def stack_remove(module_type: str) -> None:
             raise MatchaInputError(
                 f"Module '{module_type}' does not exist in the current stack."
             )
+    else:
+        raise MatchaError(
+            "No Matcha 'stack' component found in the local 'matcha.config.json' file. Please run 'matcha stack set' or matcha stack add'."
+        )

--- a/src/matcha_ml/core/core.py
+++ b/src/matcha_ml/core/core.py
@@ -18,7 +18,10 @@ from matcha_ml.config import (
     MatchaConfigComponentProperty,
     MatchaConfigService,
 )
-from matcha_ml.core._validation import is_valid_prefix, is_valid_region
+from matcha_ml.core._validation import (
+    is_valid_prefix,
+    is_valid_region,
+)
 from matcha_ml.errors import MatchaError, MatchaInputError
 from matcha_ml.runners import AzureRunner
 from matcha_ml.services.analytics_service import AnalyticsEvent, track
@@ -368,11 +371,12 @@ def stack_set(stack_name: str) -> None:
     MatchaConfigService.update(stack)
 
 
-def stack_add(module: str) -> None:
+def stack_add(module: str, flavor: str) -> None:
     """A function for adding a module by name to the stack.
 
     Args:
-        module (str): The name of the module to add.
+        module (str): The type of module to add.
+        flavor (str): The flavor of module to add.
 
     Raises:
         MatchaInputError: if the stack_name is not a valid stack type
@@ -381,6 +385,29 @@ def stack_add(module: str) -> None:
     ...
 
 
-def stack_remove(module_name: str) -> str:
-    """A placeholder for the stack remove logic in core."""
-    return module_name
+def stack_remove(module: str) -> None:
+    """A function for removing a module by name in the stack.
+
+    Args:
+        module (str): The name of the module to remove.
+
+    Raises:
+        MatchaInputError: if the stack_name is not a valid stack type
+        MatchaError: if there are already resources provisioned.
+    """
+    ...
+    # # update the stack name any time a component is added/removed.
+    # # even better would be to assess the stack and name it as llm or default if it matches, otherwise "custom".
+    # # check state exists (MatchaStateService)
+    # if not MatchaStateService.state_exists:
+    #     raise MatchaError("Matcha has detected the presence of a 'matcha.state' file. If resources are already provisioned, run `matcha destroy` before trying to modify the stack.")
+
+    # # check valid module (_validation)
+    # if not stack_module_is_valid:
+    #     raise MatchaInputError(f"'{module}' is not a valid module name")
+    # # check config file exists (MatchaConfigService)
+    # if MatchaConfigService.config_file_exists:
+    #     matcha_config = MatchaConfigService.read_matcha_config()
+    #     matcha_config.find_component("stack")
+    # else:
+    # # update config file (MatchaConfigService)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -257,11 +257,15 @@ def mocked_matcha_config_json_object() -> Dict[str, Dict[str, str]]:
         matcha_config (Dict[str, Dict[str, str]]): a dictionary representation of the matcha.config.json file
     """
     matcha_config = {
+        "stack": {
+            "name": "default",
+            "experiment_tracker": "mlflow",
+        },
         "remote_state_bucket": {
             "account_name": "test-account",
             "container_name": "test-container",
             "resource_group_name": "test-rg",
-        }
+        },
     }
 
     return matcha_config
@@ -278,7 +282,9 @@ def mocked_matcha_config_component_property() -> MatchaConfigComponentProperty:
 
 
 @pytest.fixture
-def mocked_matcha_config_component(mocked_matcha_config_json_object):
+def mocked_matcha_config_remote_state_bucket_component(
+    mocked_matcha_config_json_object,
+):
     """A fixture returning a mocked MatchaConfigComponentProperty instance.
 
     Args:
@@ -295,16 +301,42 @@ def mocked_matcha_config_component(mocked_matcha_config_json_object):
 
 
 @pytest.fixture
-def mocked_matcha_config(mocked_matcha_config_component):
+def mocked_matcha_config_stack_component(mocked_matcha_config_json_object):
+    """A fixture returning a mocked MatchaConfigComponentProperty instance.
+
+    Args:
+        mocked_matcha_config_json_object (Dict[str, Dict[str, str]]): a dictionary representation of the matcha.config.json file
+
+    Returns:
+        (MatchaConfigComponentProperty): a mocked MatchaConfigComponentProperty instance.
+    """
+    properties = []
+    for key, value in mocked_matcha_config_json_object["stack"].items():
+        properties.append(MatchaConfigComponentProperty(name=key, value=value))
+
+    return MatchaConfigComponent(name="stack", properties=properties)
+
+
+@pytest.fixture
+def mocked_matcha_config(
+    mocked_matcha_config_remote_state_bucket_component,
+    mocked_matcha_config_stack_component,
+):
     """A fixture returning a mocked MatchaConfig instance.
 
     Args:
-        mocked_matcha_config_component (MatchaConfigComponent): a mocked MatchaConfigComponent instance.
+        mocked_matcha_config_remote_state_bucket_component (MatchaConfigComponent): a mocked MatchaConfigComponent instance representing the remote storage bucket component.
+        mocked_matcha_config_stack_component (MatchaConfigComponent): a mocked MatchaConfigComponent instance representing the stack component.
 
     Returns:
         (MatchaConfig): a mocked MatchaConfig instance.
     """
-    return MatchaConfig([mocked_matcha_config_component])
+    return MatchaConfig(
+        [
+            mocked_matcha_config_stack_component,
+            mocked_matcha_config_remote_state_bucket_component,
+        ]
+    )
 
 
 @pytest.fixture

--- a/tests/test_cli/test_stack.py
+++ b/tests/test_cli/test_stack.py
@@ -66,8 +66,6 @@ def test_cli_stack_set_command_without_args(
     os.chdir(matcha_testing_directory)
     result = runner.invoke(app, ["stack", "set"])
 
-    assert result.exit_code == 0
-
     assert "Matcha 'default' stack has been set." in result.stdout
 
 

--- a/tests/test_cli/test_stack.py
+++ b/tests/test_cli/test_stack.py
@@ -213,10 +213,7 @@ def test_cli_stack_remove_command_without_args(runner: CliRunner) -> None:
     result = runner.invoke(app, ["stack", "remove"])
     assert result.exit_code == TWO_EXIT_CODE
 
-    assert (
-        "No module specified. Please run `matcha stack remove` again and provide the name\nof the module you wish to remove.\n"
-        in result.stdout
-    )
+    assert "Missing argument 'MODULE'." in result.stdout
 
 
 def test_cli_stack_add_command_with_args(

--- a/tests/test_cli/test_stack.py
+++ b/tests/test_cli/test_stack.py
@@ -211,7 +211,7 @@ def test_cli_stack_remove_command_without_args(runner: CliRunner) -> None:
         runner (CliRunner): typer CLI runner.
     """
     result = runner.invoke(app, ["stack", "remove"])
-    assert result.exit_code == 0
+    assert result.exit_code == TWO_EXIT_CODE
 
     assert (
         "No module specified. Please run `matcha stack remove` again and provide the name\nof the module you wish to remove.\n"
@@ -257,7 +257,7 @@ def test_cli_stack_remove_command_with_args(
     os.chdir(matcha_testing_directory)
     result = runner.invoke(app, ["stack", "remove", "experiment_tracker"])
 
-    assert result.exit_code == TWO_EXIT_CODE
+    assert result.exit_code == 0
     assert mocked_stack_remove.assert_called_once
     assert (
         "Matcha 'experiment_tracker' module has been removed from the current stack."

--- a/tests/test_cli/test_stack.py
+++ b/tests/test_cli/test_stack.py
@@ -9,7 +9,7 @@ from matcha_ml.cli.cli import app
 from matcha_ml.config import MatchaConfig, MatchaConfigService
 from matcha_ml.state.remote_state_manager import RemoteStateManager
 
-INTERNAL_FUNCTION_STUB = "matcha_ml.core.core"
+INTERNAL_FUNCTION_STUB = "matcha_ml.cli.cli"
 
 
 def test_cli_stack_command_help_option(runner: CliRunner) -> None:
@@ -155,10 +155,13 @@ def test_stack_set_file_modified(
 
     new_config_dict = new_config.to_dict()
 
-    assert len(new_config_dict) == len(config_dict) + 1
+    assert len(new_config_dict) == len(config_dict)
     assert "stack" in new_config_dict
     assert new_config_dict["stack"]["name"] == "llm"
-    assert config_dict.items() <= new_config_dict.items()
+    assert (
+        config_dict["remote_state_bucket"].items()
+        == new_config_dict["remote_state_bucket"].items()
+    )
 
 
 def test_cli_stack_set_add_help_option(runner: CliRunner) -> None:

--- a/tests/test_cli/test_stack.py
+++ b/tests/test_cli/test_stack.py
@@ -10,6 +10,7 @@ from matcha_ml.config import MatchaConfig, MatchaConfigService
 from matcha_ml.state.remote_state_manager import RemoteStateManager
 
 INTERNAL_FUNCTION_STUB = "matcha_ml.cli.cli"
+TWO_EXIT_CODE = 2
 
 
 def test_cli_stack_command_help_option(runner: CliRunner) -> None:
@@ -65,6 +66,8 @@ def test_cli_stack_set_command_without_args(
     """
     os.chdir(matcha_testing_directory)
     result = runner.invoke(app, ["stack", "set"])
+
+    assert result.exit_code == TWO_EXIT_CODE
 
     assert "Matcha 'default' stack has been set." in result.stdout
 
@@ -186,9 +189,6 @@ def test_cli_stack_set_remove_help_option(runner: CliRunner) -> None:
     assert result.exit_code == 0
 
     assert "Remove a module from the current Matcha stack." in result.stdout
-
-
-TWO_EXIT_CODE = 2
 
 
 def test_cli_stack_add_command_without_args(runner: CliRunner) -> None:

--- a/tests/test_cli/test_stack.py
+++ b/tests/test_cli/test_stack.py
@@ -67,7 +67,7 @@ def test_cli_stack_set_command_without_args(
     os.chdir(matcha_testing_directory)
     result = runner.invoke(app, ["stack", "set"])
 
-    assert result.exit_code == TWO_EXIT_CODE
+    assert result.exit_code == 0
 
     assert "Matcha 'default' stack has been set." in result.stdout
 
@@ -257,7 +257,7 @@ def test_cli_stack_remove_command_with_args(
     os.chdir(matcha_testing_directory)
     result = runner.invoke(app, ["stack", "remove", "experiment_tracker"])
 
-    assert result.exit_code == 0
+    assert result.exit_code == TWO_EXIT_CODE
     assert mocked_stack_remove.assert_called_once
     assert (
         "Matcha 'experiment_tracker' module has been removed from the current stack."

--- a/tests/test_config/test_matcha_config.py
+++ b/tests/test_config/test_matcha_config.py
@@ -43,6 +43,11 @@ def test_matcha_config_from_dict(
         mocked_matcha_config_json_object (Dict[str, Dict[str, str]]): a dictionary representation of the matcha.config.json file
         mocked_matcha_config (MatchaConfig): a mocked MatchaConfig instance.
     """
+    print(
+        mocked_matcha_config,
+        mocked_matcha_config.from_dict(mocked_matcha_config_json_object),
+        sep="\n",
+    )
     assert (
         mocked_matcha_config.from_dict(mocked_matcha_config_json_object)
         == mocked_matcha_config
@@ -263,20 +268,24 @@ def test_matcha_config_service_update(
 
 
 def test_remove_property_expected(
-    mocked_matcha_config_component: MatchaConfigComponent,
+    mocked_matcha_config_remote_state_bucket_component: MatchaConfigComponent,
 ):
     """Test that a component is removed if it exists.
 
     Args:
-        mocked_matcha_config_component (MatchaConfigComponent): a mocked MatchaConfigComponent instance.
+        mocked_matcha_config_remote_state_bucket_component (MatchaConfigComponent): a mocked MatchaConfigComponent instance.
     """
-    mocked_matcha_config_component.remove_property(property_name="account_name")
-    mocked_matcha_config_component.remove_property(property_name="resource_group_name")
-    mocked_matcha_config_component.remove_property(
+    mocked_matcha_config_remote_state_bucket_component.remove_property(
+        property_name="account_name"
+    )
+    mocked_matcha_config_remote_state_bucket_component.remove_property(
+        property_name="resource_group_name"
+    )
+    mocked_matcha_config_remote_state_bucket_component.remove_property(
         property_name="not_an_existing_property_name"
     )
 
-    assert mocked_matcha_config_component == MatchaConfigComponent(
+    assert mocked_matcha_config_remote_state_bucket_component == MatchaConfigComponent(
         name="remote_state_bucket",
         properties=[
             MatchaConfigComponentProperty(name="container_name", value="test-container")

--- a/tests/test_core/test_core.py
+++ b/tests/test_core/test_core.py
@@ -555,3 +555,32 @@ def test_stack_remove_with_no_module(
         stack_remove(module_type="test_module")
 
         assert "Module 'test_module' does not exist in the current stack." in str(e)
+
+
+def test_stack_remove_with_no_stack(
+    matcha_testing_directory: str,
+    mocked_matcha_config_remote_state_bucket_component: MatchaConfig,
+):
+    """Tests that the core stack_remove function raises an exception when a stack component does not exist.
+
+    Args:
+        matcha_testing_directory (str): Mock directory for testing.
+        mocked_matcha_config_remote_state_bucket_component (MatchaConfigComponent): A mocked MatchaConfigComponent object for testing.
+    """
+    os.chdir(matcha_testing_directory)
+    MatchaConfigService.write_matcha_config(
+        MatchaConfig([mocked_matcha_config_remote_state_bucket_component])
+    )
+
+    with mock.patch(
+        "matcha_ml.core.core.RemoteStateManager"
+    ) as provisioned_state, pytest.raises(MatchaError) as e:
+        mock_remote_state_manager = MagicMock()
+        mock_remote_state_manager.is_state_provisioned.return_value = False
+        provisioned_state.return_value = mock_remote_state_manager
+        stack_remove(module_type="test_module")
+
+        assert (
+            "No Matcha 'stack' component found in the local 'matcha.config.json' file. Please run 'matcha stack set' or matcha stack add'."
+            in str(e)
+        )

--- a/tests/test_core/test_stack_set.py
+++ b/tests/test_core/test_stack_set.py
@@ -69,10 +69,9 @@ def test_stack_set_existing_file(
     new_config = MatchaConfigService.read_matcha_config()
     new_config_dict = new_config.to_dict()
 
-    assert len(new_config_dict) == len(config_dict) + 1
+    assert len(new_config_dict) == len(config_dict)
     assert "stack" in new_config_dict
     assert new_config_dict["stack"]["name"] == "llm"
-    assert config_dict.items() <= new_config_dict.items()
 
 
 def test_stack_set_resources_already_provisioned():


### PR DESCRIPTION
This PR adds a core stack remove command to support the stack remove CLI command and associated API functionality. 

The command itself tests a number of things (whether state is provisioned, whether the 'stack' item appears in the config file, whether the specified module appears within the config file) and handles those potential errors accordingly. For instances where all conditions are valid, the function makes a call to the `remove_property` method of the `MatchaConfigService` to  remove the specified module.

This PR also includes full test coverage and augments some of the existing fixtures (notable the `MatchaConfig` fixture and associated fixtures) and updates existing tests accordingly.

## Checklist

Please ensure you have done the following:

* [X] I have read the [CONTRIBUTING](https://github.com/fuzzylabs/matcha/blob/main/CONTRIBUTING.md) guide.
* [ ] I have updated the documentation if required.
* [X] I have added tests which cover my changes.

## Type of change

Tick all those that apply:

* [ ] Bug Fix (non-breaking change, fixing an issue)
* [X] New feature (non-breaking change to add functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Other (add details above)
