### PR TITLE
[RPD-315] Update provisioning/destroy message for modular stack

### DIFF
--- a/src/matcha_ml/cli/cli.py
+++ b/src/matcha_ml/cli/cli.py
@@ -9,7 +9,6 @@ from matcha_ml.cli._validation import (
     prefix_typer_callback,
     region_typer_callback,
 )
-from matcha_ml.cli.constants import RESOURCE_MSG, STATE_RESOURCE_MSG
 from matcha_ml.cli.ui.print_messages import (
     print_error,
     print_resource_output,
@@ -20,10 +19,12 @@ from matcha_ml.cli.ui.resource_message_builders import (
     hide_sensitive_in_output,
 )
 from matcha_ml.cli.ui.status_message_builders import (
+    build_resources_msg_content,
     build_status,
     build_step_success_status,
 )
 from matcha_ml.cli.ui.user_approval_functions import is_user_approved
+from matcha_ml.config import MatchaConfigService
 from matcha_ml.core.core import stack_add, stack_remove
 from matcha_ml.errors import MatchaError, MatchaInputError
 
@@ -112,7 +113,10 @@ def provision(
         Exit: Exit if resources are already provisioned.
     """
     location, prefix, password = fill_provision_variables(location, prefix, password)
-    if is_user_approved(verb="provision", resources=RESOURCE_MSG):
+
+    resource_msg = build_resources_msg_content(stack=MatchaConfigService.get_stack())
+
+    if is_user_approved(verb="provision", resources=resource_msg):
         try:
             _ = core.provision(location, prefix, password, verbose)
         except MatchaError as e:
@@ -179,7 +183,10 @@ def destroy() -> None:
     Raises:
         Exit: Exit if core.destroy throws a MatchaError.
     """
-    if is_user_approved(verb="destroy", resources=RESOURCE_MSG + STATE_RESOURCE_MSG):
+    resource_msg = build_resources_msg_content(
+        stack=MatchaConfigService.get_stack(), destroy=True
+    )
+    if is_user_approved(verb="destroy", resources=resource_msg):
         try:
             core.destroy()
             print_status(build_step_success_status("Destroying resources is complete!"))

--- a/src/matcha_ml/cli/constants.py
+++ b/src/matcha_ml/cli/constants.py
@@ -1,21 +1,4 @@
 """Constants for use within the Matcha CLI."""
-RESOURCE_MSG = [
-    ("Azure Kubernetes Service (AKS)", "A kubernetes cluster"),
-    (
-        "Two Storage Containers",
-        "A storage container for experiment tracking artifacts and a second for model training artifacts",
-    ),
-    (
-        "Seldon Core",
-        "A framework for model deployment on top of a kubernetes cluster",
-    ),
-    (
-        "Azure Container Registry",
-        "A container registry for storing docker images",
-    ),
-    ("ZenServer", "A zenml server required for remote orchestration"),
-]
-
 RESOURCE_MSG_CORE = [
     ("Azure Kubernetes Service (AKS)", "A kubernetes cluster"),
     (

--- a/src/matcha_ml/cli/constants.py
+++ b/src/matcha_ml/cli/constants.py
@@ -16,6 +16,34 @@ RESOURCE_MSG = [
     ("ZenServer", "A zenml server required for remote orchestration"),
 ]
 
+RESOURCE_MSG_CORE = [
+    ("Azure Kubernetes Service (AKS)", "A kubernetes cluster"),
+    (
+        "Azure Container Registry",
+        "A container registry for storing docker images",
+    ),
+]
+
+RESOURCE_MSG_MODULES = {
+    "deployer": (
+        "Seldon Core",
+        "A framework for model deployment on top of a kubernetes cluster",
+    ),
+    "orchestrator": (
+        "ZenServer",
+        "A zenml server required for remote orchestration and a storage container",
+    ),
+    "data_version_control": (
+        "Data Version Control",
+        "A storage container to hold data versions",
+    ),
+    "experiment_tracker": (
+        "MLflow",
+        "An experiment tracker backed by a storage container",
+    ),
+    "vector_database": ("Chroma", "A vector database"),
+}
+
 STATE_RESOURCE_MSG = [
     ("Azure Resource Group", "The resource group containing the provisioned resources"),
     ("Matcha State Container", "A storage container for tracking matcha state"),

--- a/src/matcha_ml/cli/ui/status_message_builders.py
+++ b/src/matcha_ml/cli/ui/status_message_builders.py
@@ -20,7 +20,7 @@ err_console = Console(stderr=True)
 
 def build_resources_msg_content(
     stack: Optional[MatchaConfigComponent] = None, destroy: Optional[bool] = False
-) -> list[tuple[str, str]]:
+) -> List[Tuple[str, str]]:
     """Build the resource message that is outputted to the user at provision and destroy.
 
     Args:
@@ -28,7 +28,7 @@ def build_resources_msg_content(
         destroy (Optional[bool]): the message is different when destroying, set this flag when destroying. Defaults to False.
 
     Returns:
-        list[tuple[str, str]]: the resource message.
+        List[Tuple[str, str]]: the resource message.
     """
     stack_properties = DEFAULT_STACK if stack is None else stack.properties
 

--- a/src/matcha_ml/cli/ui/status_message_builders.py
+++ b/src/matcha_ml/cli/ui/status_message_builders.py
@@ -5,10 +5,42 @@ from typing import List, Optional, Tuple
 
 from rich.console import Console
 
-from matcha_ml.cli.constants import INFRA_FACTS
+from matcha_ml.cli.constants import (
+    INFRA_FACTS,
+    RESOURCE_MSG_CORE,
+    RESOURCE_MSG_MODULES,
+    STATE_RESOURCE_MSG,
+)
 from matcha_ml.cli.ui.spinner import Spinner
+from matcha_ml.config.matcha_config import MatchaConfigComponent
+from matcha_ml.constants import DEFAULT_STACK
 
 err_console = Console(stderr=True)
+
+
+def build_resources_msg_content(
+    stack: Optional[MatchaConfigComponent] = None, destroy: Optional[bool] = False
+) -> list[tuple[str, str]]:
+    """Build the resource message that is outputted to the user at provision and destroy.
+
+    Args:
+        stack (Optional[MatchaConfigComponent]): the stack to build the resource message from. Defaults to None.
+        destroy (Optional[bool]): the message is different when destroying, set this flag when destroying. Defaults to False.
+
+    Returns:
+        list[tuple[str, str]]: the resource message.
+    """
+    stack_properties = DEFAULT_STACK if stack is None else stack.properties
+
+    modules = [
+        RESOURCE_MSG_MODULES[stack_property.name]
+        for stack_property in stack_properties
+        if stack_property.name != "name"
+    ]
+
+    message = RESOURCE_MSG_CORE + modules
+
+    return message + STATE_RESOURCE_MSG if destroy else message
 
 
 def build_resource_confirmation(

--- a/src/matcha_ml/config/matcha_config.py
+++ b/src/matcha_ml/config/matcha_config.py
@@ -126,26 +126,18 @@ class MatchaConfigService:
     """A service for handling the Matcha config file."""
 
     @staticmethod
-    def get_stack() -> Optional[MatchaConfigComponentProperty]:
+    def get_stack() -> Optional[MatchaConfigComponent]:
         """Gets the current stack name from the Matcha Config if it exists.
 
         Returns:
-            Optional[MatchaConfigComponentProperty]: The name of the current stack being used as a config component object.
+            Optional[MatchaConfigComponent]: The stack config component.
         """
         try:
             stack = MatchaConfigService.read_matcha_config().find_component("stack")
         except MatchaError:
             stack = None
 
-        if stack is None:
-            return None
-
-        name = stack.find_property("name")
-
-        if name is None:
-            return None
-
-        return name
+        return None if stack is None else stack
 
     @staticmethod
     def write_matcha_config(matcha_config: MatchaConfig) -> None:

--- a/src/matcha_ml/core/core.py
+++ b/src/matcha_ml/core/core.py
@@ -18,7 +18,6 @@ from matcha_ml.config import (
     MatchaConfigComponentProperty,
     MatchaConfigService,
 )
-
 from matcha_ml.constants import DEFAULT_STACK, LLM_STACK, STACK_MODULES
 from matcha_ml.core._validation import is_valid_prefix, is_valid_region
 from matcha_ml.errors import MatchaError, MatchaInputError
@@ -310,7 +309,9 @@ def provision(
 
         stack = MatchaConfigService.get_stack()
         if stack is not None:
-            stack_name = stack.value
+            stack_property = stack.find_property("name")
+            if stack_property is not None:
+                stack_name = stack_property.value
 
         template = os.path.join(
             os.path.dirname(__file__),

--- a/tests/test_cli/test_stack.py
+++ b/tests/test_cli/test_stack.py
@@ -243,7 +243,7 @@ def test_cli_stack_add_command_with_args(
     assert result.exit_code == 0
     assert mocked_stack_add.assert_called_once
     assert (
-        "Matcha 'experiment_tracker' module of flavor 'mlflow' has been added to the current stack."
+        "Matcha 'experiment_tracker' module of flavor 'mlflow' has been added"
         in result.stdout
     )
 

--- a/tests/test_cli/test_stack.py
+++ b/tests/test_cli/test_stack.py
@@ -243,7 +243,7 @@ def test_cli_stack_add_command_with_args(
     assert result.exit_code == 0
     assert mocked_stack_add.assert_called_once
     assert (
-        "Matcha 'experiment_tracker' module of flavor 'mlflow' has been added to the \ncurrent stack.\n"
+        "Matcha 'experiment_tracker' module of flavor 'mlflow' has been added to the current stack."
         in result.stdout
     )
 

--- a/tests/test_cli/test_ui_primitives/test_status_message_builders.py
+++ b/tests/test_cli/test_ui_primitives/test_status_message_builders.py
@@ -22,7 +22,7 @@ from matcha_ml.constants import DEFAULT_STACK
 @pytest.fixture
 def matcha_stack_component_names(
     mocked_matcha_config_stack_component: MatchaConfigComponent,
-) -> list[str]:
+) -> List[str]:
     """A fixture to get the names of the modules in the stack.
 
     Args:

--- a/tests/test_cli/test_ui_primitives/test_status_message_builders.py
+++ b/tests/test_cli/test_ui_primitives/test_status_message_builders.py
@@ -3,12 +3,39 @@ from typing import List, Optional, Tuple
 
 import pytest
 
+from matcha_ml.cli.constants import (
+    RESOURCE_MSG_CORE,
+    RESOURCE_MSG_MODULES,
+    STATE_RESOURCE_MSG,
+)
 from matcha_ml.cli.ui.status_message_builders import (
     build_resource_confirmation,
+    build_resources_msg_content,
     build_status,
     build_step_success_status,
     build_substep_success_status,
 )
+from matcha_ml.config.matcha_config import MatchaConfigComponent
+from matcha_ml.constants import DEFAULT_STACK
+
+
+@pytest.fixture
+def matcha_stack_component_names(
+    mocked_matcha_config_stack_component: MatchaConfigComponent,
+) -> list[str]:
+    """A fixture to get the names of the modules in the stack.
+
+    Args:
+        mocked_matcha_config_stack_component (MatchaConfigComponent): the default stack as a component.
+
+    Returns:
+        list[str]: the names of the modules as a list.
+    """
+    return [
+        prop.name
+        for prop in mocked_matcha_config_stack_component.properties
+        if prop.name != "name"
+    ]
 
 
 @pytest.mark.parametrize(
@@ -76,3 +103,67 @@ def test_build_substep_success_status():
     """Test build substep success status formats status message correctly."""
     expected = "[green]Step finished![/green]"
     assert build_substep_success_status("Step finished!") == expected
+
+
+def test_build_resource_msg_content_expected(
+    mocked_matcha_config_stack_component: MatchaConfigComponent,
+    matcha_stack_component_names: list[str],
+):
+    """Test that the resource message has the content that we would expect for a default stack.
+
+    Args:
+        mocked_matcha_config_stack_component (MatchaConfigComponent): the default stack as a component.
+        matcha_stack_component_names (list[str]): the names of the modules in the default stack.
+    """
+    stack_modules = [
+        RESOURCE_MSG_MODULES[name] for name in matcha_stack_component_names
+    ]
+    expected_result = RESOURCE_MSG_CORE + stack_modules
+
+    resource_msg = build_resources_msg_content(
+        stack=mocked_matcha_config_stack_component, destroy=False
+    )
+
+    assert resource_msg == expected_result
+
+
+def test_build_resource_msg_content_expected_destroy(
+    mocked_matcha_config_stack_component: MatchaConfigComponent,
+    matcha_stack_component_names: list[str],
+):
+    """Test that the resource message has the content that we would expect when destroying the default stack.
+
+    Args:
+        mocked_matcha_config_stack_component (MatchaConfigComponent): the default stack as a component.
+        matcha_stack_component_names (list[str]): the names of the modules in the default stack.
+    """
+    stack_modules = [
+        RESOURCE_MSG_MODULES[name] for name in matcha_stack_component_names
+    ]
+    expected_result = RESOURCE_MSG_CORE + stack_modules + STATE_RESOURCE_MSG
+
+    resource_msg = build_resources_msg_content(
+        stack=mocked_matcha_config_stack_component, destroy=True
+    )
+
+    assert resource_msg == expected_result
+
+
+def test_build_resource_msg_content_no_stack():
+    """Test that the resource message is accurate when no stack is specified."""
+    stack_modules = [RESOURCE_MSG_MODULES[prop.name] for prop in DEFAULT_STACK]
+    expected_result = RESOURCE_MSG_CORE + stack_modules
+
+    resource_msg = build_resources_msg_content()
+
+    assert resource_msg == expected_result
+
+
+def test_build_resource_msg_content_no_stack_destroy():
+    """Test that the resource messages is accurate when no stack is specific and we're destroying."""
+    stack_modules = [RESOURCE_MSG_MODULES[prop.name] for prop in DEFAULT_STACK]
+    expected_result = RESOURCE_MSG_CORE + stack_modules + STATE_RESOURCE_MSG
+
+    resource_msg = build_resources_msg_content(destroy=True)
+
+    assert resource_msg == expected_result

--- a/tests/test_cli/test_ui_primitives/test_status_message_builders.py
+++ b/tests/test_cli/test_ui_primitives/test_status_message_builders.py
@@ -29,7 +29,7 @@ def matcha_stack_component_names(
         mocked_matcha_config_stack_component (MatchaConfigComponent): the default stack as a component.
 
     Returns:
-        list[str]: the names of the modules as a list.
+        List[str]: the names of the modules as a list.
     """
     return [
         prop.name
@@ -107,13 +107,13 @@ def test_build_substep_success_status():
 
 def test_build_resource_msg_content_expected(
     mocked_matcha_config_stack_component: MatchaConfigComponent,
-    matcha_stack_component_names: list[str],
+    matcha_stack_component_names: List[str],
 ):
     """Test that the resource message has the content that we would expect for a default stack.
 
     Args:
         mocked_matcha_config_stack_component (MatchaConfigComponent): the default stack as a component.
-        matcha_stack_component_names (list[str]): the names of the modules in the default stack.
+        matcha_stack_component_names (List[str]): the names of the modules in the default stack.
     """
     stack_modules = [
         RESOURCE_MSG_MODULES[name] for name in matcha_stack_component_names
@@ -129,13 +129,13 @@ def test_build_resource_msg_content_expected(
 
 def test_build_resource_msg_content_expected_destroy(
     mocked_matcha_config_stack_component: MatchaConfigComponent,
-    matcha_stack_component_names: list[str],
+    matcha_stack_component_names: List[str],
 ):
     """Test that the resource message has the content that we would expect when destroying the default stack.
 
     Args:
         mocked_matcha_config_stack_component (MatchaConfigComponent): the default stack as a component.
-        matcha_stack_component_names (list[str]): the names of the modules in the default stack.
+        matcha_stack_component_names (List[str]): the names of the modules in the default stack.
     """
     stack_modules = [
         RESOURCE_MSG_MODULES[name] for name in matcha_stack_component_names

--- a/tests/test_templates/test_azure_template.py
+++ b/tests/test_templates/test_azure_template.py
@@ -163,9 +163,8 @@ def test_recursively_copy_files_error_handling_directory_not_exist(
     captured = capsys.readouterr()
 
     # Check if the error message is present in the captured output
-    assert (
-        "Error while copying files: [Errno 2] No such file or directory:"
-        in captured.err
+    assert ("Error while copying files" in captured.err) and (
+        "No such file or directory" in captured.err
     )
 
 


### PR DESCRIPTION
As we've introduced modular stacks, with differing components, the provisioning and destroy resources message that's presented to the user is incorrect - it's missing components.

This PR updates the generation of that message such that it's dynamically generated based on the stack that has been set by the user. 

The `get_stack()` function has also been updated to streamline the dynamic generation. Previous, just the `name` was returned, now the whole stack component is returned.

## Checklist

Please ensure you have done the following:

* [ ] I have read the [CONTRIBUTING](https://github.com/fuzzylabs/matcha/blob/main/CONTRIBUTING.md) guide.
* [ ] I have updated the documentation if required.
* [ ] I have added tests which cover my changes.

## Type of change

Tick all those that apply:

* [ ] Bug Fix (non-breaking change, fixing an issue)
* [ ] New feature (non-breaking change to add functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Other (add details above)
