### PR TITLE
[RPD-318] Add `matcha stack list` command to list the current modules

### DIFF
--- a/src/matcha_ml/cli/cli.py
+++ b/src/matcha_ml/cli/cli.py
@@ -19,6 +19,7 @@ from matcha_ml.cli.ui.resource_message_builders import (
     hide_sensitive_in_output,
 )
 from matcha_ml.cli.ui.status_message_builders import (
+    build_resource_confirmation,
     build_resources_msg_content,
     build_status,
     build_step_success_status,
@@ -326,6 +327,17 @@ def remove(
     except MatchaError as e:
         print_error(str(e))
         raise typer.Exit()
+
+
+@stack_app.command(help="List all modules in the current Matcha stack.")
+def list() -> None:
+    """List all modules in the current Matcha stack."""
+    resources = build_resources_msg_content(stack=MatchaConfigService.get_stack())
+    resource_msg = build_resource_confirmation(
+        header="The current Matcha stack contains",
+        resources=resources,
+    )
+    print_status(resource_msg)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR adds the command

```matcha stack list```

which results in the following output:

```
The current Matcha stack contains:

1. Azure Kubernetes Service (AKS): A kubernetes cluster
2. Azure Container Registry: A container registry for storing docker images
3. ZenServer: A zenml server required for remote orchestration and a storage container
4. MLflow: An experiment tracker backed by a storage container
5. Data Version Control: A storage container to hold data versions
6. Seldon Core: A framework for model deployment on top of a kubernetes cluster
7. Chroma: A vector database
```

## Checklist

Please ensure you have done the following:

* [x] I have read the [CONTRIBUTING](https://github.com/fuzzylabs/matcha/blob/main/CONTRIBUTING.md) guide.
* [ ] I have updated the documentation if required.
* [ ] I have added tests which cover my changes.

## Type of change

Tick all those that apply:

* [ ] Bug Fix (non-breaking change, fixing an issue)
* [x] New feature (non-breaking change to add functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Other (add details above)
