### PR TITLE
Set private access for remote state storage container

### DIFF
--- a/src/matcha_ml/infrastructure/remote_state_storage/state_storage/main.tf
+++ b/src/matcha_ml/infrastructure/remote_state_storage/state_storage/main.tf
@@ -16,5 +16,5 @@ resource "azurerm_storage_account" "statestorageaccount" {
 resource "azurerm_storage_container" "statestoragecontainer" {
   name                  = "${var.prefix}statestore"
   storage_account_name  = azurerm_storage_account.statestorageaccount.name
-  container_access_type = "container"
+  container_access_type = "private"
 }


### PR DESCRIPTION
Not sure if it was intentional to set access to the remote state container with `container_access_type` as `container`. Seems like `private` would be a better setting. Terraform remote state contains lots and lots of plain-text secrets and so you don't want to enable any kind of public access.

Not sure about the downstream effects elsewhere inside Matcha from this change, but if I'm not mistaken the current setting might be risky from a security perspective.

## Checklist

Please ensure you have done the following:

* [x] I have read the [CONTRIBUTING](https://github.com/fuzzylabs/matcha/blob/main/CONTRIBUTING.md) guide.
* [x] I have updated the documentation if required.
* [ ] I have added tests which cover my changes.

## Type of change

Tick all those that apply:

* [ ] Bug Fix (non-breaking change, fixing an issue)
* [ ] New feature (non-breaking change to add functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [x] Other (add details above)
