### PR TITLE
Install terraform required to run tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
+      - uses: hashicorp/setup-terraform@v3
+
       - uses: actions/setup-python@v4
         id: setup-python
         with:

--- a/tests/test_runners/test_azure_runner.py
+++ b/tests/test_runners/test_azure_runner.py
@@ -171,12 +171,16 @@ def test_remove_matcha_dir(matcha_testing_directory: str, template_runner: Azure
     assert not os.path.exists(matcha_dir)
 
 
-def test_provision(matcha_testing_directory: str, template_runner: AzureRunner):
+def test_provision(
+    matcha_testing_directory: str, 
+    template_runner: AzureRunner, 
+    mock_output: Callable[[str, bool], Union[str, Dict[str, str]]],):
     """Test service can provision resources using terraform.
 
     Args:
         matcha_testing_directory (str): Testing directory
         template_runner (AzureRunner): a AzureRunner object instance
+        mock_output (Callable[[str, bool], Union[str, Dict[str, str]]]): the mock output
     """
     os.chdir(matcha_testing_directory)
     template_runner._check_terraform_installation = MagicMock()

--- a/tests/test_runners/test_azure_runner.py
+++ b/tests/test_runners/test_azure_runner.py
@@ -183,6 +183,7 @@ def test_provision(matcha_testing_directory: str, template_runner: AzureRunner):
     template_runner._validate_terraform_config = MagicMock()
     template_runner._initialize_terraform = MagicMock()
     template_runner._apply_terraform = MagicMock()
+    template_runner.tfs.terraform_client.output = MagicMock(wraps=mock_output)
 
     os.makedirs(os.path.join(matcha_testing_directory, ".matcha", "infrastructure"))
 


### PR DESCRIPTION
Terraform binary is required for CI to pass.

The above requirement is an anti-pattern and should not be recommended. Ideally, we should mock `self.tfs.terraform_client.output` method under [`mocked_resource_template_runner`](https://github.com/fuzzylabs/matcha/blob/5f0608ff271301919560a1561720eaf223c4309c/tests/test_cli/conftest.py#L21) and [`mocked_resource_template_runner`](https://github.com/fuzzylabs/matcha/blob/5f0608ff271301919560a1561720eaf223c4309c/tests/test_core/conftest.py#L21).

## Checklist

Please ensure you have done the following:

* [ ] I have read the [CONTRIBUTING](https://github.com/fuzzylabs/matcha/blob/main/CONTRIBUTING.md) guide.
* [ ] I have updated the documentation if required.
* [ ] I have added tests which cover my changes.

## Type of change

Tick all those that apply:

* [ ] Bug Fix (non-breaking change, fixing an issue)
* [ ] New feature (non-breaking change to add functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Other (add details above)
